### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/LicenseMapping.yml
+++ b/.github/workflows/LicenseMapping.yml
@@ -1,4 +1,6 @@
 name: Update license file
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/Nebula.Core/security/code-scanning/1](https://github.com/gioxx/Nebula.Core/security/code-scanning/1)

To fix the problem, you should add a `permissions:` block to the workflow or job definition. This block restricts the default permissions of the `GITHUB_TOKEN`, adhering to the principle of least privilege. Since this workflow commits and pushes changes to the repository, it requires `contents: write`. The minimal fix is to add:

```yaml
permissions:
  contents: write
```

This block should be added either at the top level of the workflow (applies to all jobs) or under the specific job (`check-csv:`). Since only one job is defined, both placements work; top-level placement is clearer.

**Changes to Make:**  
- Add the `permissions` block just after the workflow `name` (after line 1 or as line 2).
- No imports or additional methods needed, as this is a YAML configuration fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
