### PR TITLE
Release/1.2.1

### DIFF
--- a/Formats/Nebula.Core.Format.ps1xml
+++ b/Formats/Nebula.Core.Format.ps1xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>NebulaCoreIntuneGroupUsageTable</Name>
+      <ViewSelectedBy>
+        <TypeName>Nebula.Core.IntuneGroupUsage</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Category</Label>
+            <Width>23</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Profile Name</Label>
+            <Width>40</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Profile Type</Label>
+            <Width>55</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Assignment</Label>
+            <Width>18</Width>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Category</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Profile Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Profile Type</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <ScriptBlock>
+                  $value = $_.Assignment
+                  if ($null -eq $value) { return $null }
+                  if ($value -like '*Exclude*') {
+                    return "$($PSStyle.Foreground.BrightRed)$value$($PSStyle.Reset)"
+                  }
+                  return $value
+                </ScriptBlock>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+  </ViewDefinitions>
+</Configuration>

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -9,6 +9,9 @@
     PowerShellVersion    = '5.1'
     CompatiblePSEditions = @('Desktop', 'Core')
     RequiredAssemblies   = @()
+    FormatsToProcess     = @(
+        'Formats\Nebula.Core.Format.ps1xml'
+    )
     FunctionsToExport    = @(
         'Add-EntraGroupDevice',
         'Add-EntraGroupUser',
@@ -37,6 +40,8 @@
         'Get-EntraGroupDevice',
         'Get-EntraGroupMembers',
         'Get-EntraGroupUser',
+        'Get-IntuneProfileAssignmentsByGroup',
+        'Get-IntuneProfileAssignmentsRaw',
         'Get-MboxAlias',
         'Get-MboxLastMessageTrace',
         'Get-MboxPermission',
@@ -54,10 +59,8 @@
         'Get-UserGroups',
         'Get-UserLastSeen',
         'Get-UserMsolAccountSku',
-        'Set-MboxMrmCleanup',
         'Move-UserMsolAccountSku',
         'New-SharedMailbox',
-        'Search-MboxCutoffWindow',
         'Remove-EntraGroupDevice',
         'Remove-EntraGroupUser',
         'Remove-MboxAlias',
@@ -65,7 +68,13 @@
         'Remove-UserMsolAccountSku',
         'Revoke-UserSessions',
         'Search-EntraGroup',
+        'Search-IntuneObjectById',
+        'Search-IntuneProfileLocation',
+        'Search-IntuneProfileLocation',
+        'Search-IntuneRawEndpoint',
+        'Search-MboxCutoffWindow',
         'Set-MboxLanguage',
+        'Set-MboxMrmCleanup',
         'Set-MboxRulesQuota',
         'Set-OoO',
         'Set-SharedMboxCopyForSent',
@@ -118,10 +127,13 @@
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/Assets/icon.png'
 ReleaseNotes = @'
-- Change:
-- Fix:
-- Improve: Added positional identifier support for Entra group member cmdlets (`Add/Get/Remove-EntraGroupDevice` and `Add/Get/Remove-EntraGroupUser`), so `DeviceIdentifier` / `UserIdentifier` can be passed without explicit parameter names.
-- New:
+- Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
+- Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
+- Fix: Quarantine workflows now benefit from the improved EXO reconnection path when WAM/MSAL broker state breaks after idle, lock, or sleep.
+- Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.
+- Improve: Added support for nested group matching, diagnostic output, mixed include/exclude aggregation, and console highlighting for exclusion rows in Intune group usage results.
+- Improve: Updated `nebula-core\usage` connection and quarantine documentation to document EXO WAM fallback behavior and recovery options.
+- Improve: Updated `nebula-core\usage` documentation for the current Intune coverage and parameters.
 '@
         }
     }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -120,7 +120,7 @@
 ReleaseNotes = @'
 - Change:
 - Fix:
-- Improve:
+- Improve: Added positional identifier support for Entra group member cmdlets (`Add/Get/Remove-EntraGroupDevice` and `Add/Get/Remove-EntraGroupUser`), so `DeviceIdentifier` / `UserIdentifier` can be passed without explicit parameter names.
 - New:
 '@
         }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -132,6 +132,7 @@
 - Change: Added `New-IntuneAppBasedGroup` to create or update Entra security groups from Intune-managed devices and installed applications, with support for an explicit full group name that aggregates all matches into one group.
 - Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
 - Change: Added an optional `-Domain` filter to `Export-MsolAccountSku` so exports can be limited to users in a specific domain, matching `Mail`, `UserPrincipalName`, and `ProxyAddresses`.
+- Change: Added an optional `-License` filter to `Export-MsolAccountSku` so exports can target users holding a specific license while still including all of their assigned licenses in the CSV.
 - Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
 - Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
 - Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'Nebula.Core.psm1'
-    ModuleVersion        = '1.2.0'
+    ModuleVersion        = '1.2.1'
     GUID                 = '07acc3c0-14dc-4c1d-a1d0-6140e83c2a41'
     Author               = 'Giovanni Solone'
     Description          = 'A PowerShell module that go beyond your workstations. It will make your Microsoft 365 life easier!'
@@ -118,35 +118,10 @@
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/Assets/icon.png'
 ReleaseNotes = @'
-- Change: Add-MboxPermission now prints confirmation messages by default; use -PassThru for detailed output objects.
-- Change: Get-MboxPrimarySmtpAddress (`gpa`) now returns a compact default view (`DisplayName`, `PrimarySmtpAddress`); use `-Detailed` for full recipient fields.
-- Change: Get-UserGroups now returns `GroupName` and `GroupMail` property names (instead of spaced names) for easier scripting and filtering.
-- Change: Remove-MboxPermission now uses -ClearAll (renamed from -RemoveAllAdditionalPermissions).
-- Fix: Add-UserMsolAccountSku now accepts positional and pipeline UPN input (`<UserPrincipalName> -License ...` and `'u1','u2' | Add-UserMsolAccountSku -License ...`).
-- Fix: Add-UserMsolAccountSku now reports only actually assignable licenses in confirmation/success messages and explicitly reports skipped SKUs with zero availability.
-- Fix: Get-MboxStatistics now processes all mailbox identities received via pipeline (not only the last one).
-- Fix: Remove-MboxAlias now validates post-update proxy addresses to avoid false "removed" messages when an alias is protected (for example, WindowsLiveId).
-- Fix: Remove-MboxPermission now supports positional calls (`Remove-MboxPermission <SourceMailbox> <UserMailbox>`).
-- Fix: Remove-UserMsolAccountSku now accepts positional and pipeline UPN input (`<UserPrincipalName> -License ...` and `'u1','u2' | Remove-UserMsolAccountSku -License ...`).
-- Fix: User recipient resolve now supports short identifiers in license cmdlets by adding Graph fallback lookup on alias/SamAccountName/display name/UPN prefix.
-- Improve: Get-EntraGroupMembers can resolve registered owners/users for device members via -IncludeDeviceUsers.
-- Improve: Get-EntraGroupMembers reports device owners/users in a single column when resolved.
-- Improve: Get-MboxStatistics now always includes `ArchiveEnabled` to quickly show whether an archive exists.
-- Improve: Get-NebulaModuleUpdates now also checks ExchangeOnlineManagement and Microsoft.Graph meta modules.
-- Improve: Get-TenantMsolAccountSku now reports Available net of suspended seats and shows Total with enabled/suspended breakdown.
-- Improve: Get-UserMsolAccountSku can show tenant availability for assigned SKUs via -CheckAvailability.
-- Improve: Remove-EntraGroupDevice/Remove-EntraGroupUser can clear all group members via -ClearAll (with stronger confirmation).
-- Improve: User identifier resolution via `Find-UserRecipient` is now applied consistently across `Get/Add/Remove-EntraGroupUser` and `Disable-UserDevices`/`Disable-UserSignIn`/`Revoke-UserSessions`, including short identifiers.
-- Improve: User license cmdlets (`Add/Get/Remove/Copy/Move-UserMsolAccountSku`) now use a more consistent parameter style (positional UPNs where applicable, plus pipeline input on single-user cmdlets).
-- New: Get-EntraGroupMembers lists all members of an Entra group (users, devices, ...).
-- New: Get-MboxStatistics returns a simplified mailbox statistics view.
-- New: Get-NebulaModuleUpdates runs an on-demand update check for Nebula.* modules.
-- New: Get-TenantMsolAccountSku adds TotalCount with the numeric total for scripting.
-- New: Search-EntraGroup searches Entra groups by display name or description.
-- New: Search-MboxCutoffWindow creates/reuses Purview Compliance Searches to isolate mailbox discard sets (estimate + optional preview) before export/cleanup workflows.
-- New: Set-MboxMrmCleanup applies a temporary MRM cleanup policy/tag to a mailbox, with optional Managed Folder Assistant trigger using -RunAssistant.
-- New: Update checks during Connect-Nebula can be throttled via CheckUpdatesIntervalHours.
-- New: Update-NebulaConnections adds an explicit refresh entry point for connection status checks.
+- Change:
+- Fix:
+- Improve:
+- New:
 '@
         }
     }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -63,6 +63,7 @@
         'Get-UserMsolAccountSku',
         'Move-UserMsolAccountSku',
         'New-SharedMailbox',
+        'New-IntuneAppBasedGroup',
         'Remove-EntraGroupDevice',
         'Remove-EntraGroupUser',
         'Remove-MboxAlias',
@@ -128,7 +129,9 @@
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/Assets/icon.png'
             ReleaseNotes = @'
 - Change: Added `Export-IntuneAppInventory` for Intune app inventory reporting, with optional deployed-app status enrichment and CSV/JSON export.
+- Change: Added `New-IntuneAppBasedGroup` to create or update Entra security groups from Intune-managed devices and installed applications, with support for an explicit full group name that aggregates all matches into one group.
 - Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
+- Change: Added an optional `-Domain` filter to `Export-MsolAccountSku` so exports can be limited to users in a specific domain, matching `Mail`, `UserPrincipalName`, and `ProxyAddresses`.
 - Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
 - Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
 - Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.
@@ -136,9 +139,6 @@
 - Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.
 - Improve: Added support for nested group matching, diagnostic output, mixed include/exclude aggregation, and console highlighting for exclusion rows in Intune group usage results.
 - Improve: License user resolution now prefers Microsoft Graph identity (via shared `Find-UserRecipient -PreferGraphIdentity`) in `Add/Copy/Move/Get/Remove-UserMsolAccountSku`, with better handling of object IDs and hybrid alias lookups.
-- Improve: Updated `nebula-core\usage` connection and quarantine documentation to document EXO WAM fallback behavior and recovery options.
-- Improve: Updated `nebula-core\usage` documentation for the current Intune coverage and parameters.
-- Improve: Updated `nebula-core\usage` documentation to cover `Search-IntuneProfileLocation`, `Export-IntuneAppInventory`, and the associated examples.
 '@
         }
     }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -28,8 +28,11 @@
         'Export-CalendarPermission',
         'Export-DistributionGroups',
         'Export-DynamicDistributionGroups',
+        'Export-EmptyEntraGroups',
+        'Export-IntuneAppInventory',
         'Export-M365Group',
         'Export-MboxAlias',
+        'Export-MboxDeletedItemSize',
         'Export-MboxPermission',
         'Export-MboxStatistics',
         'Export-MsolAccountSku',
@@ -41,7 +44,6 @@
         'Get-EntraGroupMembers',
         'Get-EntraGroupUser',
         'Get-IntuneProfileAssignmentsByGroup',
-        'Get-IntuneProfileAssignmentsRaw',
         'Get-MboxAlias',
         'Get-MboxLastMessageTrace',
         'Get-MboxPermission',
@@ -68,10 +70,7 @@
         'Remove-UserMsolAccountSku',
         'Revoke-UserSessions',
         'Search-EntraGroup',
-        'Search-IntuneObjectById',
         'Search-IntuneProfileLocation',
-        'Search-IntuneProfileLocation',
-        'Search-IntuneRawEndpoint',
         'Search-MboxCutoffWindow',
         'Set-MboxLanguage',
         'Set-MboxMrmCleanup',
@@ -106,19 +105,20 @@
                 'Automation',
                 'Calendar',
                 'Configuration',
-                'Entra', 
-                'Exchange', 
+                'Entra',
+                'Exchange',
                 'Exchange-Online',
-                'Groups', 
-                'Licenses', 
-                'M365', 
-                'Mailboxes', 
-                'Microsoft', 
-                'Microsoft-365', 
+                'Groups',
+                'Intune',
+                'Licenses',
+                'M365',
+                'Mailboxes',
+                'Microsoft',
+                'Microsoft-365',
                 'Microsoft-Graph',
-                'Office-365', 
-                'PowerShell', 
-                'Quarantine', 
+                'Office-365',
+                'PowerShell',
+                'Quarantine',
                 'Reporting',
                 'Rooms',
                 'Security'
@@ -126,14 +126,19 @@
             ProjectUri   = 'https://github.com/gioxx/Nebula.Core'
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/Assets/icon.png'
-ReleaseNotes = @'
+            ReleaseNotes = @'
+- Change: Added `Export-IntuneAppInventory` for Intune app inventory reporting, with optional deployed-app status enrichment and CSV/JSON export.
+- Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
 - Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
 - Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
+- Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.
 - Fix: Quarantine workflows now benefit from the improved EXO reconnection path when WAM/MSAL broker state breaks after idle, lock, or sleep.
 - Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.
 - Improve: Added support for nested group matching, diagnostic output, mixed include/exclude aggregation, and console highlighting for exclusion rows in Intune group usage results.
+- Improve: License user resolution now prefers Microsoft Graph identity (via shared `Find-UserRecipient -PreferGraphIdentity`) in `Add/Copy/Move/Get/Remove-UserMsolAccountSku`, with better handling of object IDs and hybrid alias lookups.
 - Improve: Updated `nebula-core\usage` connection and quarantine documentation to document EXO WAM fallback behavior and recovery options.
 - Improve: Updated `nebula-core\usage` documentation for the current Intune coverage and parameters.
+- Improve: Updated `nebula-core\usage` documentation to cover `Search-IntuneProfileLocation`, `Export-IntuneAppInventory`, and the associated examples.
 '@
         }
     }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -133,8 +133,10 @@
 - Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
 - Change: Added an optional `-Domain` filter to `Export-MsolAccountSku` so exports can be limited to users in a specific domain, matching `Mail`, `UserPrincipalName`, and `ProxyAddresses`.
 - Change: Added an optional `-License` filter to `Export-MsolAccountSku` so exports can target users holding a specific license while still including all of their assigned licenses in the CSV.
+- Change: `Get-TenantMsolAccountSku` now supports `-IncludeSampleUsers` for the default sample size and renders sample-user output separately for better readability in `-AsTable` and `-GridView`.
 - Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
 - Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
+- Change: `Get-UserMsolAccountSku` now shows an explicit warning when the target user exists but has no assigned licenses.
 - Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.
 - Fix: Quarantine workflows now benefit from the improved EXO reconnection path when WAM/MSAL broker state breaks after idle, lock, or sleep.
 - Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.

--- a/Private/NC-Hlp.Configuration.ps1
+++ b/Private/NC-Hlp.Configuration.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Configuration bootstrap ==============================================================================================================
+# Nebula.Core: (Private) Configuration helpers ======================================================================================================
 
 function Import-NCConfigurationFile {
     [CmdletBinding()]

--- a/Private/NC-Hlp.Configuration.ps1
+++ b/Private/NC-Hlp.Configuration.ps1
@@ -4,6 +4,15 @@ using namespace System.Management.Automation
 # Nebula.Core: (Private) Configuration helpers ======================================================================================================
 
 function Import-NCConfigurationFile {
+    <#
+    .SYNOPSIS
+        Loads a Nebula.Core configuration file.
+    .DESCRIPTION
+        Imports a PowerShell data file and returns its hashtable content. If the file is missing or invalid,
+        returns an empty hashtable and logs the failure.
+    .PARAMETER Path
+        Path to the configuration file to import.
+    #>
     [CmdletBinding()]
     param([string]$Path)
 
@@ -25,6 +34,16 @@ function Import-NCConfigurationFile {
 }
 
 function Merge-NCConfig {
+    <#
+    .SYNOPSIS
+        Merges two configuration hashtables.
+    .DESCRIPTION
+        Copies override values into the base hashtable and returns the merged result.
+    .PARAMETER Base
+        Base configuration hashtable to update.
+    .PARAMETER Override
+        Hashtable containing values that should overwrite the base configuration.
+    #>
     [CmdletBinding()]
     param(
         [hashtable]$Base,
@@ -70,6 +89,13 @@ if (-not $script:NC_Defaults) {
 }
 
 function Initialize-NebulaConfig {
+    <#
+    .SYNOPSIS
+        Builds the effective Nebula.Core configuration.
+    .DESCRIPTION
+        Starts from module defaults, then layers machine settings, user settings, and environment overrides.
+        The merged configuration is stored in the script scope for use by the module.
+    #>
     $config = [ordered]@{}
     foreach ($key in $script:NC_Defaults.Keys) {
         $config[$key] = $script:NC_Defaults[$key]

--- a/Private/NC-Hlp.Connections.ps1
+++ b/Private/NC-Hlp.Connections.ps1
@@ -41,7 +41,7 @@ function Test-EOLConnection {
         }
 
         try {
-            Write-NCMessage "Installing Microsoft Exchange Online Management PowerShell module ..." -Level INFO
+            Write-Verbose "Installing Microsoft Exchange Online Management PowerShell module ..."
             Install-Module ExchangeOnlineManagement -Scope CurrentUser -AllowClobber -Force -ErrorAction Stop
         }
         catch {
@@ -75,7 +75,7 @@ function Test-EOLConnection {
     else {
         "Connecting to Microsoft Exchange Online Management ..."
     }
-    Write-NCMessage $message -Level INFO
+    Write-Verbose $message
 
     try {
         if ($resolvedUpn) {
@@ -154,7 +154,7 @@ function Test-MgGraphConnection {
         }
 
         try {
-            Write-NCMessage "Installing Microsoft Graph PowerShell module ..." -Level INFO
+            Write-Verbose "Installing Microsoft Graph PowerShell module ..."
             Install-Module Microsoft.Graph -Scope CurrentUser -AllowClobber -Force -ErrorAction Stop
         }
         catch {
@@ -192,7 +192,7 @@ function Test-MgGraphConnection {
                 Write-NCMessage "Existing Microsoft Graph session missing required scopes ($($missingScopes -join ', ')). Reconnecting ..." -Level WARNING
             }
             else {
-                Write-NCMessage "Microsoft Graph context not found. Establishing connection ..." -Level INFO
+                Write-Verbose "Microsoft Graph context not found. Establishing connection ..."
             }
         }
         catch {
@@ -201,7 +201,7 @@ function Test-MgGraphConnection {
     }
 
     $scopeLabel = $requestedScopes -join ', '
-    Write-NCMessage "Connecting to Microsoft Graph requesting scopes: $scopeLabel" -Level INFO
+    Write-Verbose "Connecting to Microsoft Graph requesting scopes: $scopeLabel"
 
     $connectParams = @{
         Scopes    = $requestedScopes

--- a/Private/NC-Hlp.Connections.ps1
+++ b/Private/NC-Hlp.Connections.ps1
@@ -26,7 +26,7 @@ function Test-EOLConnection {
 
     $moduleAvailable = @(Get-Module -Name ExchangeOnlineManagement -ListAvailable).Count -gt 0
     if (-not $moduleAvailable) {
-        Write-Warning "Microsoft Exchange Online Management module is not available."
+        Write-NCMessage "Microsoft Exchange Online Management module is not available." -Level WARNING
 
         $installModule = $AutoInstall.IsPresent
         if (-not $installModule) {
@@ -139,7 +139,7 @@ function Test-MgGraphConnection {
 
     $graphModuleAvailable = @(Get-Module -Name Microsoft.Graph -ListAvailable).Count -gt 0
     if (-not $graphModuleAvailable) {
-        Write-Warning "Microsoft Graph PowerShell module is not available."
+        Write-NCMessage "Microsoft Graph PowerShell module is not available." -Level WARNING
 
         $installModule = $AutoInstall.IsPresent
         if (-not $installModule) {

--- a/Private/NC-Hlp.Connections.ps1
+++ b/Private/NC-Hlp.Connections.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Connections ================================================================================================================
+# Nebula.Core: (Private) Connections helpers ========================================================================================================
 
 function Test-EOLConnection {
     <#

--- a/Private/NC-Hlp.CoreMessage.ps1
+++ b/Private/NC-Hlp.CoreMessage.ps1
@@ -29,7 +29,11 @@ function Add-EmptyLine {
     )
 
     try {
-        Write-Output ""
+        $hostMsg = [HostInformationMessage]@{
+            Message   = ''
+            NoNewline = $false
+        }
+        Write-Information -MessageData $hostMsg -InformationAction Continue
     }
     catch {
         # Ignore

--- a/Private/NC-Hlp.CoreMessage.ps1
+++ b/Private/NC-Hlp.CoreMessage.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Custom Write Information ===================================================================================================
+# Nebula.Core: (Private) Core message helpers =======================================================================================================
 
 # Script-scoped color map so it can be overridden at runtime
 # Foreground and Background are [ConsoleColor] values.

--- a/Private/NC-Hlp.Intune.ps1
+++ b/Private/NC-Hlp.Intune.ps1
@@ -3,6 +3,114 @@ using namespace System.Management.Automation
 
 # Nebula.Core: (Private) Intune helpers =============================================================================================================
 
+function Convert-NCGraphObjectToPlainObject {
+    param($Object)
+
+    if ($null -eq $Object) { return $null }
+
+    try {
+        return (($Object | ConvertTo-Json -Depth 20 -Compress) | ConvertFrom-Json -Depth 20)
+    }
+    catch {
+        return $Object
+    }
+}
+
+function Get-NCCoreProperty {
+    param($Object, [string[]]$Names)
+
+    if ($null -eq $Object) { return $null }
+    if ($Object -is [System.Collections.IDictionary]) {
+        foreach ($name in $Names) {
+            if ($Object.Contains($name) -and -not [string]::IsNullOrWhiteSpace([string]$Object[$name])) {
+                return $Object[$name]
+            }
+        }
+    }
+
+    $additionalProperties = $Object.PSObject.Properties['AdditionalProperties']
+    if ($additionalProperties -and $additionalProperties.Value -is [System.Collections.IDictionary]) {
+        foreach ($name in $Names) {
+            if ($additionalProperties.Value.Contains($name) -and -not [string]::IsNullOrWhiteSpace([string]$additionalProperties.Value[$name])) {
+                return $additionalProperties.Value[$name]
+            }
+        }
+    }
+
+    foreach ($name in $Names) {
+        $property = $Object.PSObject.Properties[$name]
+        if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+            return $property.Value
+        }
+    }
+    return $null
+}
+
+function Resolve-NCIntuneManagedDeviceEntraMember {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$ManagedDevices,
+        [Parameter(Mandatory = $true)]
+        [string]$DeviceId
+    )
+
+    $intuneDevice = $ManagedDevices | Where-Object { [string]$_.id -eq [string]$DeviceId } | Select-Object -First 1
+    $intuneDevicePlain = Convert-NCGraphObjectToPlainObject -Object $intuneDevice
+
+    $deviceLabel = Get-NCCoreProperty -Object $intuneDevicePlain -Names @('deviceName', 'DeviceName', 'displayName', 'DisplayName', 'id', 'Id')
+    if ([string]::IsNullOrWhiteSpace($deviceLabel)) {
+        $deviceLabel = [string]$DeviceId
+    }
+
+    $azureAdDeviceId = Get-NCCoreProperty -Object $intuneDevicePlain -Names @('azureADDeviceId', 'azureActiveDirectoryDeviceId', 'azureAdDeviceId')
+    if ($intuneDevicePlain -and -not $azureAdDeviceId) {
+        try {
+            $deviceDetailUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$DeviceId?`$select=id,deviceName,operatingSystem,userPrincipalName,azureADDeviceId,azureActiveDirectoryDeviceId"
+            $deviceDetails = Invoke-MgGraphRequest -Uri $deviceDetailUri -Method GET
+            $deviceDetailsPlain = Convert-NCGraphObjectToPlainObject -Object $deviceDetails
+            $azureAdDeviceId = Get-NCCoreProperty -Object $deviceDetailsPlain -Names @('azureADDeviceId', 'azureActiveDirectoryDeviceId', 'azureAdDeviceId')
+        }
+        catch {
+            Write-NCMessage "Unable to refresh Intune device details for ${deviceLabel}: $($_.Exception.Message)" -Level WARNING
+        }
+    }
+
+    if (-not $intuneDevicePlain) {
+        Write-NCMessage "No Azure AD Device ID for: $deviceLabel" -Level WARNING
+        return $null
+    }
+
+    if (-not $azureAdDeviceId) {
+        Write-NCMessage "No Azure AD Device ID for: $deviceLabel" -Level WARNING
+        return $null
+    }
+
+    $filter = "deviceId eq '$azureAdDeviceId'"
+    $entraDeviceUri = "https://graph.microsoft.com/v1.0/devices?`$filter=$filter"
+
+    try {
+        $entraDeviceResponse = Invoke-MgGraphRequest -Uri $entraDeviceUri -Method GET
+    }
+    catch {
+        Write-NCMessage "Error looking up Entra ID device for ${deviceLabel}: $($_.Exception.Message)" -Level ERROR
+        return $null
+    }
+
+    if ($entraDeviceResponse.value -and $entraDeviceResponse.value.Count -gt 0) {
+        $entraDevice = $entraDeviceResponse.value[0]
+        Write-NCMessage "Found Entra ID device: $deviceLabel -> $($entraDevice.id)" -Level INFO
+        return [pscustomobject]@{
+            IntuneDeviceId  = $DeviceId
+            EntraDeviceId   = $entraDevice.id
+            DeviceName      = $deviceLabel
+            AzureAdDeviceId = $azureAdDeviceId
+        }
+    }
+
+    Write-NCMessage "Device not found in Entra ID: $deviceLabel (Azure AD Device ID: $azureAdDeviceId)" -Level WARNING
+    return $null
+}
+
 function Invoke-NCIntuneGroupUsageCore {
     <#
     .SYNOPSIS
@@ -65,26 +173,6 @@ function Invoke-NCIntuneGroupUsageCore {
         }
 
         return @($items)
-    }
-
-    function Get-NCCoreProperty {
-        param($Object, [string[]]$Names)
-
-        if ($null -eq $Object) { return $null }
-        if ($Object -is [System.Collections.IDictionary]) {
-            foreach ($name in $Names) {
-                if ($Object.Contains($name) -and -not [string]::IsNullOrWhiteSpace([string]$Object[$name])) {
-                    return $Object[$name]
-                }
-            }
-        }
-        foreach ($name in $Names) {
-            $property = $Object.PSObject.Properties[$name]
-            if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                return $property.Value
-            }
-        }
-        return $null
     }
 
     function Test-NCCoreNameMatch {
@@ -332,7 +420,7 @@ function Invoke-NCIntuneGroupUsageCore {
     }
 
     Add-EmptyLine
-    Write-NCMessage "Scanning $($scannedIds.Count) Intune profile(s) for group '$($resolvedGroup.DisplayName)' ..." -Level VERBOSE
+    Write-Verbose "Scanning $($scannedIds.Count) Intune profile(s) for group '$($resolvedGroup.DisplayName)' ..."
 
     foreach ($entity in $deviceConfigurations) {
         $entityId = [string](Get-NCCoreProperty -Object $entity -Names @('id', 'Id'))
@@ -379,7 +467,7 @@ function Invoke-NCIntuneGroupUsageCore {
     $sorted = $results | Sort-Object 'Category', 'Profile Name', 'Assignment' -Unique
 
     Add-EmptyLine
-    Write-NCMessage "Intune profiles found for '$($resolvedGroup.DisplayName)': $($sorted.Count)" -Level VERBOSE
+    Write-Verbose "Intune profiles found for '$($resolvedGroup.DisplayName)': $($sorted.Count)"
 
     if ($sorted.Count -eq 0) {
         Write-NCMessage "No Intune profiles found for group '$($resolvedGroup.DisplayName)'." -Level WARNING
@@ -431,7 +519,7 @@ function Invoke-NCGraphCollectionRequest {
             }
 
             if ($requestCount % 10 -eq 0) {
-                Write-NCMessage "." -Level INFO -NoNewline
+                Write-Verbose "."
             }
 
             $nextLink = $response.'@odata.nextLink'
@@ -439,7 +527,7 @@ function Invoke-NCGraphCollectionRequest {
         }
         catch {
             if ($_.Exception.Message -like '*429*') {
-                Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
+                Write-Verbose "`nRate limit hit, waiting 60 seconds ..."
                 Start-Sleep -Seconds 60
                 continue
             }
@@ -492,12 +580,12 @@ function Invoke-NCGraphAllPagesCore {
 
             $nextLink = $response.'@odata.nextLink'
             if ($requestCount % 10 -eq 0) {
-                Write-NCMessage "." -Level INFO -NoNewline
+                Write-Verbose "."
             }
         }
         catch {
             if ($_.Exception.Message -like "*429*") {
-                Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
+                Write-Verbose "`nRate limit hit, waiting 60 seconds ..."
                 Start-Sleep -Seconds 60
                 continue
             }

--- a/Private/NC-Hlp.Intune.ps1
+++ b/Private/NC-Hlp.Intune.ps1
@@ -1,0 +1,369 @@
+# Nebula.Core: (Private) Intune helpers =============================================================================================================
+
+function Invoke-NCIntuneGroupUsageCore {
+    [CmdletBinding()]
+    param(
+        [string]$ParameterSetName,
+        [string]$GroupName,
+        [string]$GroupId,
+        [string]$ProfileName,
+        [string]$ProfileId,
+        [switch]$IncludeNestedGroups,
+        [switch]$GridView,
+        [switch]$Diagnostic
+    )
+
+    function Invoke-NCGraphPagedRequestCore {
+        param([Parameter(Mandatory = $true)][string]$Uri)
+
+        $items = [System.Collections.Generic.List[object]]::new()
+        $nextUri = $Uri
+        while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+            $response = Invoke-MgGraphRequest -Uri $nextUri -Method Get -ErrorAction Stop
+            $pageItems = @()
+
+            if ($response -is [System.Collections.IDictionary]) {
+                if ($response.Contains('value')) { $pageItems = @($response['value']) }
+                elseif ($response.Contains('id')) { $pageItems = @($response) }
+                if ($response.Contains('@odata.nextLink')) { $nextUri = [string]$response['@odata.nextLink'] } else { $nextUri = $null }
+            }
+            else {
+                if ($response.PSObject.Properties['value']) { $pageItems = @($response.value) }
+                elseif ($response.PSObject.Properties['id']) { $pageItems = @($response) }
+                if ($response.PSObject.Properties['@odata.nextLink']) { $nextUri = [string]$response.'@odata.nextLink' } else { $nextUri = $null }
+            }
+
+            foreach ($item in $pageItems) {
+                if ($null -ne $item) { $items.Add($item) | Out-Null }
+            }
+        }
+
+        return @($items)
+    }
+
+    function Get-NCCoreProperty {
+        param($Object, [string[]]$Names)
+
+        if ($null -eq $Object) { return $null }
+        if ($Object -is [System.Collections.IDictionary]) {
+            foreach ($name in $Names) {
+                if ($Object.Contains($name) -and -not [string]::IsNullOrWhiteSpace([string]$Object[$name])) {
+                    return $Object[$name]
+                }
+            }
+        }
+        foreach ($name in $Names) {
+            $property = $Object.PSObject.Properties[$name]
+            if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                return $property.Value
+            }
+        }
+        return $null
+    }
+
+    function Test-NCCoreNameMatch {
+        param([string]$CandidateName, [string]$FilterName)
+        if ([string]::IsNullOrWhiteSpace($FilterName)) { return $true }
+        if ([string]::IsNullOrWhiteSpace($CandidateName)) { return $false }
+        return $CandidateName -like "*$FilterName*"
+    }
+
+    function Resolve-NCCoreGroupName {
+        param([string]$Id)
+        if ([string]::IsNullOrWhiteSpace($Id)) { return $null }
+        if ($script:NCIntuneGroupNameCache -and $script:NCIntuneGroupNameCache.ContainsKey($Id)) {
+            return $script:NCIntuneGroupNameCache[$Id]
+        }
+        if (-not $script:NCIntuneGroupNameCache) {
+            $script:NCIntuneGroupNameCache = @{}
+        }
+        $name = $null
+        try {
+            $groupInfo = Get-MgGroup -GroupId $Id -ErrorAction Stop
+            $name = $groupInfo.DisplayName
+        }
+        catch {
+            $name = $null
+        }
+        $script:NCIntuneGroupNameCache[$Id] = $name
+        return $name
+    }
+
+    function Get-NCCoreEffectiveGroupIds {
+        param([string]$RootGroupId)
+
+        $ids = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        [void]$ids.Add($RootGroupId)
+
+        if (-not $IncludeNestedGroups.IsPresent) {
+            return $ids
+        }
+
+        try {
+            $parents = @(Get-MgGroupTransitiveMemberOf -GroupId $RootGroupId -All -ErrorAction Stop)
+        }
+        catch {
+            try {
+                $parents = @(Get-MgGroupMemberOf -GroupId $RootGroupId -All -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to resolve parent groups for '$RootGroupId': $($_.Exception.Message)" -Level WARNING
+                return $ids
+            }
+        }
+
+        foreach ($parent in $parents) {
+            $odataType = $null
+            if ($parent.AdditionalProperties -and $parent.AdditionalProperties.ContainsKey('@odata.type')) {
+                $odataType = [string]$parent.AdditionalProperties['@odata.type']
+            }
+            if ($odataType -and $odataType -notmatch 'group') { continue }
+            $parentId = [string](Get-NCCoreProperty -Object $parent -Names @('id', 'Id'))
+            if (-not [string]::IsNullOrWhiteSpace($parentId)) {
+                [void]$ids.Add($parentId)
+            }
+        }
+
+        return $ids
+    }
+
+    function Get-NCCoreAssignmentRecords {
+        param(
+            [string]$EntityType,
+            [string]$EntityId,
+            [System.Collections.Generic.HashSet[string]]$EffectiveGroupIds,
+            [string]$RequestedGroupId
+        )
+
+        $uri = switch ($EntityType) {
+            'deviceConfigurations' { "beta/deviceManagement/deviceConfigurations('$EntityId')/assignments" }
+            'configurationPolicies' { "beta/deviceManagement/configurationPolicies('$EntityId')/assignments" }
+            'mobileApps' { "beta/deviceAppManagement/mobileApps('$EntityId')/assignments" }
+            default { $null }
+        }
+        if (-not $uri) { return @() }
+
+        try {
+            $assignments = @(Invoke-NCGraphPagedRequestCore -Uri $uri)
+        }
+        catch {
+            Write-NCMessage "Unable to read assignments for '$EntityType' object '$EntityId': $($_.Exception.Message)" -Level WARNING
+            return @()
+        }
+
+        $records = [System.Collections.Generic.List[object]]::new()
+        foreach ($assignment in $assignments) {
+            $target = Get-NCCoreProperty -Object $assignment -Names @('target', 'Target')
+            if (-not $target) { continue }
+
+            $odataType = [string](Get-NCCoreProperty -Object $target -Names @('@odata.type'))
+            $targetGroupId = [string](Get-NCCoreProperty -Object $target -Names @('groupId', 'GroupId'))
+            $intent = [string](Get-NCCoreProperty -Object $assignment -Names @('intent', 'Intent'))
+            if (-not [string]::IsNullOrWhiteSpace($intent)) { $intent = $intent.ToLowerInvariant() }
+
+            $reason = $null
+            switch ($odataType) {
+                '#microsoft.graph.groupAssignmentTarget' {
+                    if ($EffectiveGroupIds.Contains($targetGroupId)) {
+                        $reason = if ($targetGroupId -eq $RequestedGroupId) { 'Direct Assignment' } else { 'Group Assignment' }
+                    }
+                }
+                '#microsoft.graph.exclusionGroupAssignmentTarget' {
+                    if ($EffectiveGroupIds.Contains($targetGroupId)) {
+                        $reason = if ($targetGroupId -eq $RequestedGroupId) { 'Direct Exclusion' } else { 'Group Exclusion' }
+                    }
+                }
+            }
+
+            if (-not $reason -and -not $Diagnostic.IsPresent) { continue }
+
+            $records.Add([pscustomobject]@{
+                    Reason          = $reason
+                    GroupId         = $targetGroupId
+                    GroupName       = Resolve-NCCoreGroupName -Id $targetGroupId
+                    AssignmentId    = [string](Get-NCCoreProperty -Object $assignment -Names @('id', 'Id'))
+                    TargetODataType = $odataType
+                    Intent          = $intent
+                }) | Out-Null
+        }
+
+        return @($records)
+    }
+
+    function Resolve-NCCoreAssignmentValue {
+        param([object[]]$Assignments)
+
+        $hasInclude = @($Assignments | Where-Object { $_.Reason -in @('Direct Assignment', 'Group Assignment') }).Count -gt 0
+        $hasExclude = @($Assignments | Where-Object { $_.Reason -in @('Direct Exclusion', 'Group Exclusion') }).Count -gt 0
+
+        if ($hasInclude -and $hasExclude) { return 'Include; Exclude' }
+        if ($hasExclude) { return 'Exclude' }
+        if ($hasInclude) { return 'Include' }
+        return $null
+    }
+
+    function Add-NCCoreResult {
+        param(
+            [System.Collections.Generic.List[object]]$Results,
+            [string]$Category,
+            $Item,
+            [string]$Source,
+            [object[]]$Assignments,
+            $ResolvedGroup,
+            [string]$AppIntent
+        )
+
+        $itemId = [string](Get-NCCoreProperty -Object $Item -Names @('id', 'Id'))
+        $itemName = [string](Get-NCCoreProperty -Object $Item -Names @('displayName', 'DisplayName', 'name', 'Name'))
+        $itemType = [string](Get-NCCoreProperty -Object $Item -Names @('@odata.type'))
+
+        if ($ProfileId -and $itemId -ne $ProfileId) { return }
+        if (-not (Test-NCCoreNameMatch -CandidateName $itemName -FilterName $ProfileName)) { return }
+
+        $assignmentValue = Resolve-NCCoreAssignmentValue -Assignments $Assignments
+        if (-not $assignmentValue -and -not $Diagnostic.IsPresent) { return }
+
+        $row = [ordered]@{
+            'Category'     = $Category
+            'Profile Name' = $itemName
+            'Profile Type' = $itemType
+            'Assignment'   = $assignmentValue
+        }
+
+        if ($GridView.IsPresent -or $Diagnostic.IsPresent) {
+            $row['Profile Id'] = $itemId
+            $row['Source'] = $Source
+            $row['Group Name'] = $ResolvedGroup.DisplayName
+            $row['Group Id'] = $ResolvedGroup.Id
+            $row['Assignment Id'] = (($Assignments | ForEach-Object { $_.AssignmentId } | Where-Object { $_ } | Select-Object -Unique) -join '; ')
+            $row['Target OData Type'] = (($Assignments | ForEach-Object { $_.TargetODataType } | Where-Object { $_ } | Select-Object -Unique) -join '; ')
+            $row['Target Group Id'] = (($Assignments | ForEach-Object { $_.GroupId } | Where-Object { $_ } | Select-Object -Unique) -join '; ')
+            $row['Target Group Name'] = (($Assignments | ForEach-Object { $_.GroupName } | Where-Object { $_ } | Select-Object -Unique) -join '; ')
+            $row['Matched Requested Group'] = (@($Assignments | Where-Object { $_.Reason }).Count -gt 0)
+            if ($AppIntent) { $row['App Intent'] = $AppIntent }
+        }
+
+        $resultObject = [pscustomobject]$row
+        $resultObject.PSObject.TypeNames.Insert(0, 'Nebula.Core.IntuneGroupUsage')
+        $Results.Add($resultObject) | Out-Null
+    }
+
+    if (-not (Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false)) {
+        Add-EmptyLine
+        Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        return
+    }
+
+    if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+        Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+        return
+    }
+
+    try {
+        if ($ParameterSetName -eq 'ById') {
+            $resolvedGroup = Get-MgGroup -GroupId $GroupId -ErrorAction Stop
+        }
+        else {
+            $groupCandidates = @(Get-MgGroup -Filter "displayName eq '$GroupName'" -ConsistencyLevel eventual -CountVariable ignored -All -ErrorAction Stop)
+            if ($groupCandidates.Count -eq 0) {
+                Write-NCMessage "No Entra group found with display name '$GroupName'." -Level WARNING
+                return
+            }
+            if ($groupCandidates.Count -gt 1) {
+                Write-NCMessage "Multiple Entra groups found with display name '$GroupName'. Use -GroupId instead." -Level ERROR
+                return
+            }
+            $resolvedGroup = $groupCandidates[0]
+        }
+    }
+    catch {
+        Write-NCMessage "Unable to resolve target group: $($_.Exception.Message)" -Level ERROR
+        return
+    }
+
+    $effectiveGroupIds = Get-NCCoreEffectiveGroupIds -RootGroupId $resolvedGroup.Id
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    $deviceConfigurations = @()
+    $configurationPolicies = @()
+    $mobileApps = @()
+
+    try { $deviceConfigurations = @(Invoke-NCGraphPagedRequestCore -Uri 'beta/deviceManagement/deviceConfigurations') }
+    catch { Write-NCMessage "Unable to retrieve Intune device configurations: $($_.Exception.Message)" -Level WARNING }
+
+    try { $configurationPolicies = @(Invoke-NCGraphPagedRequestCore -Uri 'beta/deviceManagement/configurationPolicies') }
+    catch { Write-NCMessage "Unable to retrieve Intune configuration policies: $($_.Exception.Message)" -Level WARNING }
+
+    try { $mobileApps = @(Invoke-NCGraphPagedRequestCore -Uri "beta/deviceAppManagement/mobileApps?`$filter=isAssigned eq true") }
+    catch { Write-NCMessage "Unable to retrieve Intune mobile apps: $($_.Exception.Message)" -Level WARNING }
+
+    $scannedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($collection in @($deviceConfigurations, $configurationPolicies, $mobileApps)) {
+        foreach ($entry in @($collection)) {
+            $entryId = [string](Get-NCCoreProperty -Object $entry -Names @('id', 'Id'))
+            if (-not [string]::IsNullOrWhiteSpace($entryId)) { [void]$scannedIds.Add($entryId) }
+        }
+    }
+
+    Add-EmptyLine
+    Write-NCMessage "Scanning $($scannedIds.Count) Intune profile(s) for group '$($resolvedGroup.DisplayName)' ..." -Level VERBOSE
+
+    foreach ($entity in $deviceConfigurations) {
+        $entityId = [string](Get-NCCoreProperty -Object $entity -Names @('id', 'Id'))
+        if ([string]::IsNullOrWhiteSpace($entityId)) { continue }
+        $assignments = @(Get-NCCoreAssignmentRecords -EntityType 'deviceConfigurations' -EntityId $entityId -EffectiveGroupIds $effectiveGroupIds -RequestedGroupId $resolvedGroup.Id)
+        Add-NCCoreResult -Results $results -Category 'Device Configuration' -Item $entity -Source 'deviceConfigurations' -Assignments $assignments -ResolvedGroup $resolvedGroup
+    }
+
+    foreach ($entity in $configurationPolicies) {
+        $entityId = [string](Get-NCCoreProperty -Object $entity -Names @('id', 'Id'))
+        if ([string]::IsNullOrWhiteSpace($entityId)) { continue }
+        $assignments = @(Get-NCCoreAssignmentRecords -EntityType 'configurationPolicies' -EntityId $entityId -EffectiveGroupIds $effectiveGroupIds -RequestedGroupId $resolvedGroup.Id)
+        Add-NCCoreResult -Results $results -Category 'Settings Catalog Policy' -Item $entity -Source 'configurationPolicies' -Assignments $assignments -ResolvedGroup $resolvedGroup
+    }
+
+    foreach ($entity in $mobileApps) {
+        if ($entity.isFeatured -or $entity.isBuiltIn) { continue }
+        $entityId = [string](Get-NCCoreProperty -Object $entity -Names @('id', 'Id'))
+        if ([string]::IsNullOrWhiteSpace($entityId)) { continue }
+
+        $assignments = @(Get-NCCoreAssignmentRecords -EntityType 'mobileApps' -EntityId $entityId -EffectiveGroupIds $effectiveGroupIds -RequestedGroupId $resolvedGroup.Id)
+        if ($assignments.Count -eq 0 -and -not $Diagnostic.IsPresent) { continue }
+
+        $intentGroups = @{}
+        foreach ($assignment in $assignments) {
+            if ([string]::IsNullOrWhiteSpace($assignment.Intent)) { continue }
+            if (-not $intentGroups.ContainsKey($assignment.Intent)) {
+                $intentGroups[$assignment.Intent] = [System.Collections.Generic.List[object]]::new()
+            }
+            $intentGroups[$assignment.Intent].Add($assignment) | Out-Null
+        }
+
+        foreach ($intent in $intentGroups.Keys) {
+            $category = switch ($intent) {
+                'required' { 'Required App' }
+                'available' { 'Available App' }
+                'uninstall' { 'Uninstall App' }
+                default { 'Assigned App' }
+            }
+            Add-NCCoreResult -Results $results -Category $category -Item $entity -Source 'mobileApps' -Assignments @($intentGroups[$intent]) -ResolvedGroup $resolvedGroup -AppIntent $intent
+        }
+    }
+
+    $sorted = $results | Sort-Object 'Category', 'Profile Name', 'Assignment' -Unique
+
+    Add-EmptyLine
+    Write-NCMessage "Intune profiles found for '$($resolvedGroup.DisplayName)': $($sorted.Count)" -Level VERBOSE
+
+    if ($sorted.Count -eq 0) {
+        Write-NCMessage "No Intune profiles found for group '$($resolvedGroup.DisplayName)'." -Level WARNING
+        return
+    }
+
+    if ($GridView.IsPresent) {
+        $sorted | Out-GridView -Title "Intune Profiles - $($resolvedGroup.DisplayName)"
+    }
+    else {
+        $sorted
+    }
+}

--- a/Private/NC-Hlp.Intune.ps1
+++ b/Private/NC-Hlp.Intune.ps1
@@ -98,7 +98,7 @@ function Resolve-NCIntuneManagedDeviceEntraMember {
 
     if ($entraDeviceResponse.value -and $entraDeviceResponse.value.Count -gt 0) {
         $entraDevice = $entraDeviceResponse.value[0]
-        Write-NCMessage "Found Entra ID device: $deviceLabel -> $($entraDevice.id)" -Level INFO
+        Write-Verbose "Found Entra ID device: $deviceLabel -> $($entraDevice.id)"
         return [pscustomobject]@{
             IntuneDeviceId  = $DeviceId
             EntraDeviceId   = $entraDevice.id

--- a/Private/NC-Hlp.Intune.ps1
+++ b/Private/NC-Hlp.Intune.ps1
@@ -4,6 +4,29 @@ using namespace System.Management.Automation
 # Nebula.Core: (Private) Intune helpers =============================================================================================================
 
 function Invoke-NCIntuneGroupUsageCore {
+    <#
+    .SYNOPSIS
+        Core Intune group usage lookup logic.
+    .DESCRIPTION
+        Resolves the requested Entra group, scans supported Intune surfaces, and returns matching assignment
+        records. This is the implementation behind the public group usage command.
+    .PARAMETER ParameterSetName
+        Active parameter set name from the public wrapper.
+    .PARAMETER GroupName
+        Target group display name.
+    .PARAMETER GroupId
+        Target group object ID.
+    .PARAMETER ProfileName
+        Optional filter for the profile or app display name.
+    .PARAMETER ProfileId
+        Optional filter for a specific Intune object ID.
+    .PARAMETER IncludeNestedGroups
+        Also include parent groups that contain the requested group.
+    .PARAMETER GridView
+        Show results in Out-GridView when requested.
+    .PARAMETER Diagnostic
+        Include diagnostic columns in the returned objects.
+    #>
     [CmdletBinding()]
     param(
         [string]$ParameterSetName,
@@ -372,6 +395,15 @@ function Invoke-NCIntuneGroupUsageCore {
 }
 
 function Invoke-NCGraphCollectionRequest {
+    <#
+    .SYNOPSIS
+        Retrieves a Graph collection with pagination.
+    .DESCRIPTION
+        Repeatedly calls Microsoft Graph until no next link remains, with light throttling and basic 429 retry
+        handling.
+    .PARAMETER Uri
+        Initial Graph request URI.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -399,7 +431,7 @@ function Invoke-NCGraphCollectionRequest {
             }
 
             if ($requestCount % 10 -eq 0) {
-                Write-Information "." -InformationAction Continue
+                Write-NCMessage "." -Level INFO -NoNewline
             }
 
             $nextLink = $response.'@odata.nextLink'
@@ -407,12 +439,12 @@ function Invoke-NCGraphCollectionRequest {
         }
         catch {
             if ($_.Exception.Message -like '*429*') {
-                Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
                 Start-Sleep -Seconds 60
                 continue
             }
 
-            Write-Warning "Error fetching data: $($_.Exception.Message)"
+            Write-NCMessage "Error fetching data: $($_.Exception.Message)" -Level WARNING
             break
         }
     }
@@ -421,6 +453,16 @@ function Invoke-NCGraphCollectionRequest {
 }
 
 function Invoke-NCGraphAllPagesCore {
+    <#
+    .SYNOPSIS
+        Retrieves all pages from a Graph endpoint.
+    .DESCRIPTION
+        Follows @odata.nextLink until the collection is exhausted and returns all items as an array.
+    .PARAMETER Uri
+        Initial Graph request URI.
+    .PARAMETER DelayMs
+        Delay in milliseconds between follow-up page requests.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -450,17 +492,17 @@ function Invoke-NCGraphAllPagesCore {
 
             $nextLink = $response.'@odata.nextLink'
             if ($requestCount % 10 -eq 0) {
-                Write-Information "." -InformationAction Continue
+                Write-NCMessage "." -Level INFO -NoNewline
             }
         }
         catch {
             if ($_.Exception.Message -like "*429*") {
-                Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
                 Start-Sleep -Seconds 60
                 continue
             }
 
-            Write-Warning "Error fetching data: $($_.Exception.Message)"
+            Write-NCMessage "Error fetching data: $($_.Exception.Message)" -Level WARNING
             break
         }
     }
@@ -470,6 +512,14 @@ function Invoke-NCGraphAllPagesCore {
 }
 
 function Get-NCIntuneItemName {
+    <#
+    .SYNOPSIS
+        Returns the best display name for an Intune object.
+    .DESCRIPTION
+        Reads common display-name properties and returns the first non-empty value.
+    .PARAMETER Item
+        Intune object to inspect.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
@@ -489,6 +539,14 @@ function Get-NCIntuneItemName {
 }
 
 function Get-NCIntuneItemId {
+    <#
+    .SYNOPSIS
+        Returns the best identifier for an Intune object.
+    .DESCRIPTION
+        Reads common id properties and returns the first non-empty value.
+    .PARAMETER Item
+        Intune object to inspect.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
@@ -508,6 +566,14 @@ function Get-NCIntuneItemId {
 }
 
 function Get-NCIntuneItemODataType {
+    <#
+    .SYNOPSIS
+        Returns the OData type for an Intune object.
+    .DESCRIPTION
+        Reads the standard @odata.type property or falls back to AdditionalProperties when available.
+    .PARAMETER Item
+        Intune object to inspect.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
@@ -530,6 +596,14 @@ function Get-NCIntuneItemODataType {
 }
 
 function Get-NCIntuneSearchFields {
+    <#
+    .SYNOPSIS
+        Returns searchable fields for an Intune object.
+    .DESCRIPTION
+        Collects common identifying and descriptive properties into a normalized search field list.
+    .PARAMETER Item
+        Intune object to inspect.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
@@ -553,6 +627,14 @@ function Get-NCIntuneSearchFields {
 }
 
 function Get-NCIntuneAppTypeFromODataType {
+    <#
+    .SYNOPSIS
+        Maps an Intune app OData type to a friendly app type.
+    .DESCRIPTION
+        Translates common Microsoft Graph Intune app type names into a short label used by the module.
+    .PARAMETER ODataType
+        OData type string to translate.
+    #>
     [CmdletBinding()]
     param([string]$ODataType)
 
@@ -573,6 +655,17 @@ function Get-NCIntuneAppTypeFromODataType {
 }
 
 function Test-NCIntuneVersionAtLeast {
+    <#
+    .SYNOPSIS
+        Compares two version strings.
+    .DESCRIPTION
+        Returns $true when the current version is greater than or equal to the minimum version. Falls back
+        to string comparison if the inputs cannot be parsed as [version].
+    .PARAMETER CurrentVersion
+        Current version string.
+    .PARAMETER MinimumVersion
+        Minimum version string to compare against.
+    #>
     [CmdletBinding()]
     param(
         [string]$CurrentVersion,
@@ -594,4 +687,50 @@ function Test-NCIntuneVersionAtLeast {
     }
 
     return $CurrentVersion -ge $MinimumVersion
+}
+
+function Get-NCIntuneAppBasedGroupName {
+    <#
+    .SYNOPSIS
+        Builds a sanitized Entra group name for app-based Intune groups.
+    .DESCRIPTION
+        Uses an explicit group name when provided, otherwise removes invalid characters, collapses
+        separators, trims edges, and enforces the Entra group name length limit while preserving the
+        requested prefix and suffix.
+    .PARAMETER GroupName
+        Explicit full group name to use as-is instead of generating one from prefix and suffix.
+    .PARAMETER AppName
+        Application display name used as the base for the group name.
+    .PARAMETER GroupPrefix
+        Prefix prepended to the sanitized application name.
+    .PARAMETER GroupSuffix
+        Suffix appended to the sanitized application name.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$GroupName,
+        [Parameter(Mandatory = $false)]
+        [string]$AppName,
+        [Parameter(Mandatory = $false)]
+        [string]$GroupPrefix = 'Devices-With-',
+        [Parameter(Mandatory = $false)]
+        [string]$GroupSuffix = ''
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($GroupName)) {
+        return $GroupName
+    }
+
+    $sanitized = $AppName -replace '[^\w\s-]', ''
+    $sanitized = $sanitized -replace '\s+', '-'
+    $sanitized = $sanitized -replace '-+', '-'
+    $sanitized = $sanitized.Trim('-')
+
+    $maxLength = 256 - $GroupPrefix.Length - $GroupSuffix.Length
+    if ($sanitized.Length -gt $maxLength) {
+        $sanitized = $sanitized.Substring(0, $maxLength)
+    }
+
+    return "${GroupPrefix}${sanitized}${GroupSuffix}"
 }

--- a/Private/NC-Hlp.Intune.ps1
+++ b/Private/NC-Hlp.Intune.ps1
@@ -1,3 +1,6 @@
+#Requires -Version 5.0
+using namespace System.Management.Automation
+
 # Nebula.Core: (Private) Intune helpers =============================================================================================================
 
 function Invoke-NCIntuneGroupUsageCore {
@@ -366,4 +369,229 @@ function Invoke-NCIntuneGroupUsageCore {
     else {
         $sorted
     }
+}
+
+function Invoke-NCGraphCollectionRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri
+    )
+
+    $items = [System.Collections.Generic.List[object]]::new()
+    $nextUri = $Uri
+    $requestCount = 0
+
+    while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+        try {
+            if ($requestCount -gt 0) {
+                Start-Sleep -Milliseconds 100
+            }
+
+            $response = Invoke-MgGraphRequest -Uri $nextUri -Method GET -ErrorAction Stop
+            $requestCount++
+
+            if ($response.PSObject.Properties['value']) {
+                $items.AddRange(@($response.value))
+            }
+            else {
+                $items.AddRange(@($response))
+            }
+
+            if ($requestCount % 10 -eq 0) {
+                Write-Information "." -InformationAction Continue
+            }
+
+            $nextLink = $response.'@odata.nextLink'
+            $nextUri = if ($nextLink) { [string]$nextLink } else { $null }
+        }
+        catch {
+            if ($_.Exception.Message -like '*429*') {
+                Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                Start-Sleep -Seconds 60
+                continue
+            }
+
+            Write-Warning "Error fetching data: $($_.Exception.Message)"
+            break
+        }
+    }
+
+    return @($items)
+}
+
+function Invoke-NCGraphAllPagesCore {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [int]$DelayMs = 100
+    )
+
+    $allResults = @()
+    $nextLink = $Uri
+    $requestCount = 0
+
+    do {
+        try {
+            if ($requestCount -gt 0) {
+                Start-Sleep -Milliseconds $DelayMs
+            }
+
+            $response = Invoke-MgGraphRequest -Uri $nextLink -Method GET
+            $requestCount++
+
+            if ($response.value) {
+                $allResults += $response.value
+            }
+            else {
+                $allResults += $response
+            }
+
+            $nextLink = $response.'@odata.nextLink'
+            if ($requestCount % 10 -eq 0) {
+                Write-Information "." -InformationAction Continue
+            }
+        }
+        catch {
+            if ($_.Exception.Message -like "*429*") {
+                Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                Start-Sleep -Seconds 60
+                continue
+            }
+
+            Write-Warning "Error fetching data: $($_.Exception.Message)"
+            break
+        }
+    }
+    while ($nextLink)
+
+    return $allResults
+}
+
+function Get-NCIntuneItemName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Item
+    )
+
+    if (-not $Item) { return $null }
+
+    foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
+        $property = $Item.PSObject.Properties[$propertyName]
+        if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+            return [string]$property.Value
+        }
+    }
+
+    return $null
+}
+
+function Get-NCIntuneItemId {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Item
+    )
+
+    if (-not $Item) { return $null }
+
+    foreach ($propertyName in @('id', 'Id')) {
+        $property = $Item.PSObject.Properties[$propertyName]
+        if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+            return [string]$property.Value
+        }
+    }
+
+    return $null
+}
+
+function Get-NCIntuneItemODataType {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Item
+    )
+
+    if (-not $Item) { return $null }
+
+    $odataProperty = $Item.PSObject.Properties['@odata.type']
+    if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
+        return [string]$odataProperty.Value
+    }
+
+    $additionalProperties = $Item.PSObject.Properties['AdditionalProperties']
+    if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
+        return [string]$additionalProperties.Value['@odata.type']
+    }
+
+    return $null
+}
+
+function Get-NCIntuneSearchFields {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        $Item
+    )
+
+    $fields = [System.Collections.Generic.List[object]]::new()
+    if (-not $Item) { return $fields.ToArray() }
+
+    foreach ($propertyName in @('id', 'Id', 'displayName', 'DisplayName', 'name', 'Name', 'description', 'Description', 'networkName', 'NetworkName', 'ssid', 'Ssid')) {
+        $property = $Item.PSObject.Properties[$propertyName]
+        if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+            $fields.Add([pscustomobject]@{
+                    Property = $propertyName
+                    Value    = [string]$property.Value
+                }) | Out-Null
+        }
+    }
+
+    return $fields.ToArray()
+}
+
+function Get-NCIntuneAppTypeFromODataType {
+    [CmdletBinding()]
+    param([string]$ODataType)
+
+    switch ($ODataType) {
+        '#microsoft.graph.win32LobApp' { return 'Win32' }
+        '#microsoft.graph.microsoftStoreForBusinessApp' { return 'Store' }
+        '#microsoft.graph.webApp' { return 'Web' }
+        '#microsoft.graph.officeSuiteApp' { return 'Office' }
+        '#microsoft.graph.winGetApp' { return 'WinGet' }
+        '#microsoft.graph.iosLobApp' { return 'iOS' }
+        '#microsoft.graph.iosStoreApp' { return 'iOS' }
+        '#microsoft.graph.androidManagedStoreApp' { return 'Android' }
+        '#microsoft.graph.androidLobApp' { return 'Android' }
+        '#microsoft.graph.macOSLobApp' { return 'macOS' }
+        '#microsoft.graph.macOSOfficeSuiteApp' { return 'macOS' }
+        default { return 'Other' }
+    }
+}
+
+function Test-NCIntuneVersionAtLeast {
+    [CmdletBinding()]
+    param(
+        [string]$CurrentVersion,
+        [string]$MinimumVersion
+    )
+
+    if ([string]::IsNullOrWhiteSpace($MinimumVersion)) {
+        return $true
+    }
+
+    if ([string]::IsNullOrWhiteSpace($CurrentVersion)) {
+        return $false
+    }
+
+    $currentParsed = [version]'0.0'
+    $minimumParsed = [version]'0.0'
+    if ([version]::TryParse($CurrentVersion, [ref]$currentParsed) -and [version]::TryParse($MinimumVersion, [ref]$minimumParsed)) {
+        return $currentParsed -ge $minimumParsed
+    }
+
+    return $CurrentVersion -ge $MinimumVersion
 }

--- a/Private/NC-Hlp.Licenses.ps1
+++ b/Private/NC-Hlp.Licenses.ps1
@@ -166,8 +166,8 @@ function Get-LicenseSourceData {
 
     $needDownload = $ForceRefresh.IsPresent -or -not (Test-Path -LiteralPath $cacheFile)
     
-    Write-NCMessage ("License cache state: ForceRefresh={0} CacheExists={1} LastCheckedUtc={2:o} CacheDays={3} TTL={4} NeedDownload={5} CurrentCommit={6:o} RemoteCommit={7:o}" -f `
-            $ForceRefresh.IsPresent, (Test-Path -LiteralPath $cacheFile), $lastCheckedUtc, $CacheDays, $ttl, $needDownload, $currentCommitUtc, $remoteCommitUtc) -Level VERBOSE
+    Write-Verbose ("License cache state: ForceRefresh={0} CacheExists={1} LastCheckedUtc={2:o} CacheDays={3} TTL={4} NeedDownload={5} CurrentCommit={6:o} RemoteCommit={7:o}" -f `
+            $ForceRefresh.IsPresent, (Test-Path -LiteralPath $cacheFile), $lastCheckedUtc, $CacheDays, $ttl, $needDownload, $currentCommitUtc, $remoteCommitUtc)
 
     if (-not $needDownload -and $lastCheckedUtc) {
         if ($nowUtc - $lastCheckedUtc -ge $ttl) {
@@ -236,7 +236,7 @@ function Get-LicenseSourceData {
 
             $licenseItems | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $cacheFile -Encoding UTF8
             $source = 'Remote'
-            Write-NCMessage "License file downloaded and cached at $cacheFile." -Level VERBOSE
+            Write-Verbose "License file downloaded and cached at $cacheFile."
 
             if (-not $remoteCommitUtc) {
                 $remoteCommitUtc = $nowUtc
@@ -338,10 +338,10 @@ function Get-LicenseCatalog {
     }
 
     if ($IncludeMetadata.IsPresent -and $primaryData.LastCommitUtc) {
-        Write-NCMessage "License catalog last updated: $($primaryData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $primaryData.Source)" -Level VERBOSE
+        Write-Verbose "License catalog last updated: $($primaryData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $primaryData.Source)"
     }
     if ($IncludeMetadata.IsPresent -and $customData -and $customData.LastCommitUtc) {
-        Write-NCMessage "Custom license catalog last updated: $($customData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $customData.Source)" -Level VERBOSE
+        Write-Verbose "Custom license catalog last updated: $($customData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $customData.Source)"
     }
 
     return [pscustomobject]@{

--- a/Private/NC-Hlp.Licenses.ps1
+++ b/Private/NC-Hlp.Licenses.ps1
@@ -61,6 +61,15 @@ function Get-NormalizedLicenseKey {
 }
 
 function New-LicenseLookup {
+    <#
+    .SYNOPSIS
+        Builds a lookup table for license identifiers.
+    .DESCRIPTION
+        Converts catalog items into a normalized hash table keyed by SKU identifier so friendly names can be
+        resolved quickly.
+    .PARAMETER Items
+        License catalog items to index.
+    #>
     [CmdletBinding()]
     param([object[]]$Items)
 
@@ -157,8 +166,8 @@ function Get-LicenseSourceData {
 
     $needDownload = $ForceRefresh.IsPresent -or -not (Test-Path -LiteralPath $cacheFile)
     
-    Write-Verbose ("License cache state: ForceRefresh={0} CacheExists={1} LastCheckedUtc={2:o} CacheDays={3} TTL={4} NeedDownload={5} CurrentCommit={6:o} RemoteCommit={7:o}" -f `
-            $ForceRefresh.IsPresent, (Test-Path -LiteralPath $cacheFile), $lastCheckedUtc, $CacheDays, $ttl, $needDownload, $currentCommitUtc, $remoteCommitUtc)
+    Write-NCMessage ("License cache state: ForceRefresh={0} CacheExists={1} LastCheckedUtc={2:o} CacheDays={3} TTL={4} NeedDownload={5} CurrentCommit={6:o} RemoteCommit={7:o}" -f `
+            $ForceRefresh.IsPresent, (Test-Path -LiteralPath $cacheFile), $lastCheckedUtc, $CacheDays, $ttl, $needDownload, $currentCommitUtc, $remoteCommitUtc) -Level VERBOSE
 
     if (-not $needDownload -and $lastCheckedUtc) {
         if ($nowUtc - $lastCheckedUtc -ge $ttl) {
@@ -329,10 +338,10 @@ function Get-LicenseCatalog {
     }
 
     if ($IncludeMetadata.IsPresent -and $primaryData.LastCommitUtc) {
-        Write-Verbose "License catalog last updated: $($primaryData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $primaryData.Source)"
+        Write-NCMessage "License catalog last updated: $($primaryData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $primaryData.Source)" -Level VERBOSE
     }
     if ($IncludeMetadata.IsPresent -and $customData -and $customData.LastCommitUtc) {
-        Write-Verbose "Custom license catalog last updated: $($customData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $customData.Source)"
+        Write-NCMessage "Custom license catalog last updated: $($customData.LastCommitUtc.ToLocalTime().ToString($NCVars.DateTimeString_Full)) (source: $customData.Source)" -Level VERBOSE
     }
 
     return [pscustomobject]@{

--- a/Private/NC-Hlp.Licenses.ps1
+++ b/Private/NC-Hlp.Licenses.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Licenses's Utilities =======================================================================================================
+# Nebula.Core: (Private) Licenses helpers ===========================================================================================================
 
 function Get-LicenseCacheInfo {
     <#

--- a/Private/NC-Hlp.Mailboxes.ps1
+++ b/Private/NC-Hlp.Mailboxes.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Mailboxes's utilities ======================================================================================================
+# Nebula.Core: (Private) Mailboxes helpers ==========================================================================================================
 
 function Resolve-MbxQuotaValue {
     <#

--- a/Private/NC-Hlp.ModuleUpdates.ps1
+++ b/Private/NC-Hlp.ModuleUpdates.ps1
@@ -133,6 +133,12 @@ function Test-NebulaModuleUpdates {
 }
 
 function Get-NCModuleUpdateLastCheck {
+    <#
+    .SYNOPSIS
+        Returns the timestamp of the last module update check.
+    .DESCRIPTION
+        Reads the cached update-check file and returns the stored UTC timestamp when available.
+    #>
     [CmdletBinding()]
     param()
 
@@ -156,6 +162,12 @@ function Get-NCModuleUpdateLastCheck {
 }
 
 function Save-NCModuleUpdateLastCheck {
+    <#
+    .SYNOPSIS
+        Persists the module update check timestamp.
+    .DESCRIPTION
+        Writes the current UTC time to the update-check file under the Nebula.Core user configuration root.
+    #>
     [CmdletBinding()]
     param()
 
@@ -173,6 +185,12 @@ function Save-NCModuleUpdateLastCheck {
 }
 
 function Get-NCModuleUpdateCheckPath {
+    <#
+    .SYNOPSIS
+        Returns the module update check file path.
+    .DESCRIPTION
+        Builds the path to the local JSON file used to store the last update check timestamp.
+    #>
     [CmdletBinding()]
     param()
 

--- a/Private/NC-Hlp.ModuleUpdates.ps1
+++ b/Private/NC-Hlp.ModuleUpdates.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Module update checks =================================================================================================================
+# Nebula.Core: (Private) Module update helpers ======================================================================================================
 
 function Test-NebulaModuleUpdates {
     <#

--- a/Private/NC-Hlp.ModuleUtils.ps1
+++ b/Private/NC-Hlp.ModuleUtils.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Module's Utilities =========================================================================================================
+# Nebula.Core: (Private) Module helpers =============================================================================================================
 
 function Format-OutputString {
     <#

--- a/Private/NC-Hlp.Quarantine.ps1
+++ b/Private/NC-Hlp.Quarantine.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) Quarantine's utilities =====================================================================================================
+# Nebula.Core: (Private) Quarantine helpers =========================================================================================================
 
 function ConvertTo-QuarantineMessageId {
     <#

--- a/Private/NC-Hlp.UserUtils.ps1
+++ b/Private/NC-Hlp.UserUtils.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: (Private) User's Utilities ===========================================================================================================
+# Nebula.Core: (Private) User helpers ===============================================================================================================
 
 function Find-UserConnected {
     <#
@@ -49,27 +49,27 @@ function Find-UserConnected {
     }
 }
 
-
 function Find-UserRecipient {
     <#
     .SYNOPSIS
-        Resolves and returns the primary SMTP address of a user recipient.
+        Resolves and returns a user identity for Exchange or Microsoft Graph usage.
     .DESCRIPTION
-        Given a User Principal Name (UPN) or identifier, this function queries Exchange to find the recipient.
-        It returns the primary SMTP address, ensuring a complete e-mail format.
-        If direct lookup fails, it tries Microsoft Graph lookups for common short identifiers
-        (for example mailNickname/SamAccountName/displayName) and uses the first match.
+        By default, this function preserves the historical behavior and returns the user's
+        primary SMTP address when available.
+        When -PreferGraphIdentity is specified, the function prefers a Graph-friendly identity
+        such as the Entra object ID or the user principal name.
     .PARAMETER UserPrincipalName
         The UPN or identifier of the user recipient to resolve.
-    .EXAMPLE
-        Find-UserRecipient -UserPrincipalName "john.doe"
+    .PARAMETER PreferGraphIdentity
+        Returns a Graph-friendly identity instead of the primary SMTP address.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$UserPrincipalName
+        [string]$UserPrincipalName,
+        [switch]$PreferGraphIdentity
     )
-    
+
     if ([string]::IsNullOrWhiteSpace($UserPrincipalName)) {
         return
     }
@@ -78,18 +78,23 @@ function Find-UserRecipient {
         $recipient = Get-Recipient -Identity $UserPrincipalName -ErrorAction Stop
     }
     catch {
-        # If no Exchange recipient exists yet (e.g., user without mailbox), fall back to Graph user info
         try {
-            $user = Get-MgUser -UserId $UserPrincipalName -ErrorAction Stop
-            $fallbackUpn = if ($user.Mail) { $user.Mail } else { $user.UserPrincipalName }
-            if ($fallbackUpn) {
-                return $fallbackUpn
+            $user = Get-MgUser -UserId $UserPrincipalName -Property Id, UserPrincipalName, Mail -ErrorAction Stop
+
+            if ($PreferGraphIdentity.IsPresent) {
+                return $user.Id
             }
+
+            if ($user.Mail) {
+                return $user.Mail
+            }
+
+            return $user.UserPrincipalName
         }
         catch {
-            # Try Graph search for short identifiers like alias/SamAccountName/displayName.
             $escaped = $UserPrincipalName.Replace("'", "''")
             $queries = @()
+
             if ($UserPrincipalName -match '@') {
                 $queries += "userPrincipalName eq '$escaped'"
                 $queries += "mail eq '$escaped'"
@@ -101,31 +106,36 @@ function Find-UserRecipient {
                 $queries += "startswith(userPrincipalName,'$escaped@')"
             }
 
-            $matches = @()
+            $matchedUsers = @()
             foreach ($query in $queries) {
                 try {
-                    $matches = @(Get-MgUser -Filter $query -All -Property Id,UserPrincipalName,Mail,DisplayName -ErrorAction Stop)
-                    if ($matches.Count -gt 0) {
+                    $matchedUsers = @(Get-MgUser -Filter $query -All -Property Id, UserPrincipalName, Mail, DisplayName -ErrorAction Stop)
+                    if ($matchedUsers.Count -gt 0) {
                         break
                     }
                 }
                 catch {
-                    # Ignore unsupported/failed filter attempts and continue with the next strategy.
                     continue
                 }
             }
 
-            if ($matches.Count -gt 0) {
-                $selected = $matches | Sort-Object UserPrincipalName | Select-Object -First 1
-                if ($matches.Count -gt 1) {
-                    $selectedLabel = if ($selected.UserPrincipalName) { $selected.UserPrincipalName } else { $selected.DisplayName }
+            if ($matchedUsers.Count -gt 0) {
+                $selectedUser = $matchedUsers | Sort-Object UserPrincipalName | Select-Object -First 1
+
+                if ($matchedUsers.Count -gt 1) {
+                    $selectedLabel = if ($selectedUser.UserPrincipalName) { $selectedUser.UserPrincipalName } else { $selectedUser.DisplayName }
                     Write-NCMessage "Multiple users matched '$UserPrincipalName'. Using the first result ($selectedLabel)." -Level WARNING
                 }
 
-                $fallbackUpn = if ($selected.Mail) { $selected.Mail } else { $selected.UserPrincipalName }
-                if ($fallbackUpn) {
-                    return $fallbackUpn
+                if ($PreferGraphIdentity.IsPresent) {
+                    return $selectedUser.Id
                 }
+
+                if ($selectedUser.Mail) {
+                    return $selectedUser.Mail
+                }
+
+                return $selectedUser.UserPrincipalName
             }
 
             Write-NCMessage "Recipient not available or not found ($UserPrincipalName). $($_.Exception.Message)" -Level ERROR
@@ -139,24 +149,45 @@ function Find-UserRecipient {
         return
     }
 
-    $UserPrincipalName = $recipient.PrimarySmtpAddress
-    if (-not $UserPrincipalName) {
-        $UserPrincipalName = $recipient.WindowsLiveID
+    if ($PreferGraphIdentity.IsPresent) {
+        if ($recipient.ExternalDirectoryObjectId) {
+            return [string]$recipient.ExternalDirectoryObjectId
+        }
+
+        if ($recipient.WindowsLiveID -and $recipient.WindowsLiveID -match '@') {
+            return [string]$recipient.WindowsLiveID
+        }
+
+        if ($recipient.PrimarySmtpAddress) {
+            return [string]$recipient.PrimarySmtpAddress
+        }
+
+        $primaryGraphCandidate = @($recipient.EmailAddresses | Where-Object { $_ -clike 'SMTP:*' } | Select-Object -First 1)
+        if ($primaryGraphCandidate.Count -gt 0) {
+            return $primaryGraphCandidate[0].Substring(5)
+        }
+
+        return
     }
 
-    if ($UserPrincipalName -notmatch '@') {
+    $resolvedAddress = $recipient.PrimarySmtpAddress
+    if (-not $resolvedAddress) {
+        $resolvedAddress = $recipient.WindowsLiveID
+    }
+
+    if ($resolvedAddress -notmatch '@') {
         $primaryMatches = @($recipient.EmailAddresses | Where-Object { $_ -clike 'SMTP:*' })
         if ($primaryMatches.Count -eq 0) {
-            Write-NCMessage "Complete e-mail address not specified and no primary SMTP address found for $UserPrincipalName." -Level WARNING
+            Write-NCMessage "Complete e-mail address not specified and no primary SMTP address found for $resolvedAddress." -Level WARNING
             return
         }
 
         if ($primaryMatches.Count -gt 1) {
-            Write-NCMessage "Multiple SMTP addresses detected for $UserPrincipalName. Using the first match ($($primaryMatches[0].Substring(5)))." -Level WARNING
+            Write-NCMessage "Multiple SMTP addresses detected for $resolvedAddress. Using the first match ($($primaryMatches[0].Substring(5)))." -Level WARNING
         }
 
-        $UserPrincipalName = $primaryMatches[0].Substring(5)
+        $resolvedAddress = $primaryMatches[0].Substring(5)
     }
 
-    return $UserPrincipalName
+    return $resolvedAddress
 }

--- a/Public/NC.Calendar.ps1
+++ b/Public/NC.Calendar.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Calendar =============================================================================================================================
+# Nebula.Core: Calendar helpers =====================================================================================================================
 
 function Copy-OoOMessage {
     <#

--- a/Public/NC.Calendar.ps1
+++ b/Public/NC.Calendar.ps1
@@ -223,7 +223,7 @@ function Export-CalendarPermission {
             foreach ($mailbox in $targets) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($targets.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($targets.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($targets.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity -ErrorAction Stop
@@ -360,7 +360,7 @@ function Get-RoomDetails {
             foreach ($group in $roomGroups) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($roomGroups.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $($roomGroups.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $($roomGroups.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $members = Get-DistributionGroupMember -Identity $group.PrimarySmtpAddress -ResultSize Unlimited -ErrorAction Stop

--- a/Public/NC.Calendar.ps1
+++ b/Public/NC.Calendar.ps1
@@ -222,8 +222,8 @@ function Export-CalendarPermission {
 
             foreach ($mailbox in $targets) {
                 $counter++
-                $percent = (($counter / $targets.Count) * 100)
-                Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($targets.Count) ($($percent.ToString('0.00'))%)" -PercentComplete $percent
+                $Percentage = [Math]::Round(($counter / [Math]::Max($targets.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($targets.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity -ErrorAction Stop
@@ -359,8 +359,8 @@ function Get-RoomDetails {
             $counter = 0
             foreach ($group in $roomGroups) {
                 $counter++
-                $percentComplete = (($counter / $roomGroups.Count) * 100)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $($roomGroups.Count) ($($percentComplete.ToString('0.0'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($counter / [Math]::Max($roomGroups.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $($roomGroups.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $members = Get-DistributionGroupMember -Identity $group.PrimarySmtpAddress -ResultSize Unlimited -ErrorAction Stop

--- a/Public/NC.Compliance.ps1
+++ b/Public/NC.Compliance.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Compliance ===========================================================================================================================
+# Nebula.Core: Compliance helpers ===================================================================================================================
 
 function Search-MboxCutoffWindow {
     <#

--- a/Public/NC.Configuration.ps1
+++ b/Public/NC.Configuration.ps1
@@ -1,5 +1,7 @@
 #Requires -Version 5.0
 
+# Nebula.Core: Configuration helpers ================================================================================================================
+
 function Get-NebulaConfig {
     <#
     .SYNOPSIS
@@ -21,15 +23,6 @@ function Get-NebulaConfig {
         MachineConfigExists= $info.MachineConfigExists
         MachineConfigLoaded= $info.MachineConfigLoaded
     }
-
-    # $envRows = foreach ($key in $info.EnvironmentOverrideKeys) {
-    #     $envVar = "NEBULA_{0}" -f ($key.ToUpperInvariant())
-    #     [pscustomobject]@{
-    #         Key    = $key
-    #         EnvVar = $envVar
-    #         Value  = [Environment]::GetEnvironmentVariable($envVar)
-    #     }
-    # }
 
     $configRows = foreach ($key in ($script:NC_Config.Keys | Sort-Object)) {
         [pscustomobject]@{
@@ -74,13 +67,6 @@ function Get-NebulaConfig {
         }
         Show-Table -Rows $userRows -AsTable
     }
-
-    # return [pscustomobject]@{
-    #     Summary              = $summary
-    #     EnvironmentOverrides = $envRows
-    #     ActiveConfiguration  = $configRows
-    #     LicenseSources       = $licenseRows
-    # }
 }
 
 function Sync-NebulaConfig {

--- a/Public/NC.Connections.ps1
+++ b/Public/NC.Connections.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Connections ==========================================================================================================================
+# Nebula.Core: Connections helpers ==================================================================================================================
 
 function Connect-EOL {
     <#

--- a/Public/NC.Connections.ps1
+++ b/Public/NC.Connections.ps1
@@ -15,6 +15,12 @@ function Connect-EOL {
         UPN/e-mail used for the authentication prompt. Defaults to the current user.
     .PARAMETER DelegatedOrganization
         Optional customer tenant to target when running in delegated admin scenarios.
+    .PARAMETER DisableWAM
+        Disable Web Account Manager (WAM) for the Exchange Online sign-in flow.
+    .PARAMETER Device
+        Use device-code authentication instead of the default interactive flow.
+    .PARAMETER NoWamFallback
+        Do not automatically retry with -DisableWAM when the default WAM-based flow fails.
     .PARAMETER PassThru
         Return the Connect-ExchangeOnline result (session info) to the caller.
     .EXAMPLE
@@ -28,6 +34,9 @@ function Connect-EOL {
         [Alias('UPN', 'User')]
         [string]$UserPrincipalName,
         [string]$DelegatedOrganization,
+        [switch]$DisableWAM,
+        [switch]$Device,
+        [switch]$NoWamFallback,
         [switch]$PassThru
     )
 
@@ -63,8 +72,42 @@ function Connect-EOL {
             $connectParams.DelegatedOrganization = $DelegatedOrganization
         }
 
-        Write-NCMessage "Connecting to Exchange Online as $UserPrincipalName ..." -Level INFO
-        $session = Connect-ExchangeOnline @connectParams
+        if ($DisableWAM.IsPresent) {
+            $connectParams.DisableWAM = $true
+        }
+
+        if ($Device.IsPresent) {
+            $connectParams.Device = $true
+        }
+
+        $authMode = if ($Device.IsPresent) {
+            'device code'
+        }
+        elseif ($DisableWAM.IsPresent) {
+            'interactive without WAM'
+        }
+        else {
+            'interactive (WAM)'
+        }
+
+        Write-NCMessage "Connecting to Exchange Online as $UserPrincipalName using $authMode ..." -Level INFO
+
+        try {
+            $session = Connect-ExchangeOnline @connectParams
+        }
+        catch {
+            $shouldRetryWithoutWam = (-not $DisableWAM.IsPresent) -and (-not $Device.IsPresent) -and (-not $NoWamFallback.IsPresent)
+            $exceptionText = $_ | Out-String
+
+            if ($shouldRetryWithoutWam -and $exceptionText -match '(?i)(RuntimeBroker|Web Account Manager|\bWAM\b|Error Acquiring Token|NullReferenceException)') {
+                Write-NCMessage "Exchange Online sign-in via WAM failed. Retrying with WAM disabled ..." -Level WARNING
+                $connectParams.DisableWAM = $true
+                $session = Connect-ExchangeOnline @connectParams
+            }
+            else {
+                throw
+            }
+        }
 
         if ($PassThru.IsPresent) {
             return $session

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -457,8 +457,8 @@ function Export-DistributionGroups {
 
             foreach ($group in $groups) {
                 $counter++
-                $percentComplete = (($counter / $total) * 100)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-DistributionGroupMember -Identity $group.Identity -ResultSize Unlimited -ErrorAction Stop)
@@ -640,8 +640,8 @@ function Export-DynamicDistributionGroups {
 
             foreach ($group in $groups) {
                 $counter++
-                $percentComplete = (($counter / $total) * 100)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-DynamicDistributionGroupMember -Identity $group.Identity -ErrorAction Stop)
@@ -823,8 +823,8 @@ function Export-M365Group {
 
             foreach ($group in $groups) {
                 $counter++
-                $percentComplete = (($counter / $total) * 100)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-UnifiedGroupLinks -Identity $group.Identity -LinkType Member -ErrorAction Stop)
@@ -1097,8 +1097,8 @@ function Get-RoleGroupsMembers {
 
         foreach ($group in $roleGroups) {
             $counter++
-            $percentComplete = (($counter / $total) * 100)
-            Write-Progress -Activity "Processing $($group.Name)" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($group.Name)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
             try {
                 $members = @(Get-RoleGroupMember -Identity $group.Identity -ErrorAction Stop)
@@ -1250,7 +1250,7 @@ function Get-UserGroups {
         }
 
         Add-EmptyLine
-        Write-NCMessage "$recipientType ($resolvedPrincipal) - Groups found: $($memberships.Count)" -Level VERBOSE
+        Write-Verbose "$recipientType ($resolvedPrincipal) - Groups found: $($memberships.Count)"
 
         if (-not $memberships -or $memberships.Count -eq 0) {
             Write-NCMessage "No groups found for $resolvedPrincipal." -Level WARNING
@@ -1374,7 +1374,7 @@ function Get-EntraGroupDevice {
         }
 
         Add-EmptyLine
-        Write-NCMessage "Device ($deviceLabel) - Groups found: $($memberships.Count)" -Level VERBOSE
+        Write-Verbose "Device ($deviceLabel) - Groups found: $($memberships.Count)"
 
         if (-not $memberships -or $memberships.Count -eq 0) {
             Write-NCMessage "No groups found for $deviceLabel." -Level WARNING
@@ -1493,7 +1493,7 @@ function Search-EntraGroup {
         }
 
         Add-EmptyLine
-        Write-NCMessage "Groups found: $($groups.Count) for '$SearchText'." -Level VERBOSE
+        Write-Verbose "Groups found: $($groups.Count) for '$SearchText'."
 
         if (-not $groups -or $groups.Count -eq 0) {
             Write-NCMessage "No groups found for '$SearchText'." -Level WARNING
@@ -1573,8 +1573,8 @@ function Export-EmptyEntraGroups {
 
             foreach ($group in $groups) {
                 $processedCount++
-                $percentComplete = (($processedCount / $totalGroups) * 100)
-                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalGroups, 1)) * 100, 2)
+                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop)
@@ -1749,7 +1749,7 @@ function Get-EntraGroupUser {
         }
 
         Add-EmptyLine
-        Write-NCMessage "User ($userLabel) - Groups found: $($memberships.Count)" -Level VERBOSE
+        Write-Verbose "User ($userLabel) - Groups found: $($memberships.Count)"
 
         if (-not $memberships -or $memberships.Count -eq 0) {
             Write-NCMessage "No groups found for $userLabel." -Level WARNING
@@ -1866,7 +1866,7 @@ function Get-EntraGroupMembers {
     }
 
     Add-EmptyLine
-    Write-NCMessage "Group ($($resolvedGroup.DisplayName)) - Members found: $($members.Count)" -Level VERBOSE
+    Write-Verbose "Group ($($resolvedGroup.DisplayName)) - Members found: $($members.Count)"
 
     if (-not $members -or $members.Count -eq 0) {
         Write-NCMessage "No members found for $($resolvedGroup.DisplayName)." -Level WARNING

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -34,7 +34,8 @@ function Add-EntraGroupDevice {
         [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('Device', 'DeviceName', 'Id', 'DeviceId', 'Name')]
         [string[]]$DeviceIdentifier,
 
@@ -206,7 +207,8 @@ function Add-EntraGroupUser {
         [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('User', 'UPN', 'Mail', 'Id', 'UserId')]
         [string[]]$UserIdentifier,
 
@@ -1303,7 +1305,7 @@ function Get-EntraGroupDevice {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('Device', 'DeviceName', 'Id', 'DeviceId', 'Name', 'Identity', 'DisplayName')]
         [string]$DeviceIdentifier,
         [switch]$TreatInputAsId,
@@ -1545,7 +1547,7 @@ function Get-EntraGroupUser {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('User', 'UPN', 'Mail', 'Id', 'UserId', 'DisplayName', 'Identity')]
         [string]$UserIdentifier,
         [switch]$TreatInputAsId,
@@ -1893,8 +1895,8 @@ function Remove-EntraGroupDevice {
         [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllById')]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ById', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('Device', 'DeviceName', 'Id', 'DeviceId', 'Name')]
         [string[]]$DeviceIdentifier,
 
@@ -2149,8 +2151,8 @@ function Remove-EntraGroupUser {
         [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllById')]
         [string]$GroupId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Parameter(Mandatory = $true, ParameterSetName = 'ById', ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [Alias('User', 'UPN', 'Mail', 'Id', 'UserId')]
         [string[]]$UserIdentifier,
 

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Groups ===============================================================================================================================
+# Nebula.Core: Groups helpers =======================================================================================================================
 
 function Add-EntraGroupDevice {
     <#
@@ -1523,6 +1523,117 @@ function Search-EntraGroup {
         }
         else {
             $results | Sort-Object 'Group Name'
+        }
+    }
+}
+
+function Export-EmptyEntraGroups {
+    <#
+    .SYNOPSIS
+        Exports Entra groups that have no members.
+    .DESCRIPTION
+        Connects to Microsoft Graph, enumerates groups, checks membership for each one, and exports
+        the groups with zero members to CSV by default.
+    .PARAMETER CsvFolder
+        Destination folder for the CSV file when exporting the report.
+    .PARAMETER Csv
+        When present, export the report to CSV. Defaults to on.
+    .EXAMPLE
+        Export-EmptyEntraGroups
+    .EXAMPLE
+        Export-EmptyEntraGroups -CsvFolder 'C:\Reports\Groups'
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$CsvFolder,
+        [bool]$Csv = $true
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $report = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+        try {
+            if (-not (Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $groups = @(Get-MgGroup -All -ErrorAction Stop)
+            if (-not $groups -or $groups.Count -eq 0) {
+                Write-NCMessage "No Entra groups found." -Level WARNING
+                return
+            }
+
+            $totalGroups = $groups.Count
+            $processedCount = 0
+
+            foreach ($group in $groups) {
+                $processedCount++
+                $percentComplete = (($processedCount / $totalGroups) * 100)
+                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+
+                try {
+                    $members = @(Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop)
+                }
+                catch {
+                    Write-NCMessage "Unable to read members for group '$($group.DisplayName)'. $($_.Exception.Message)" -Level WARNING
+                    continue
+                }
+
+                if ($members.Count -gt 0) {
+                    continue
+                }
+
+                $groupType = if ($group.GroupTypes -contains 'Unified' -and $group.SecurityEnabled) {
+                    'Microsoft 365 (security-enabled)'
+                }
+                elseif ($group.GroupTypes -contains 'Unified' -and -not $group.SecurityEnabled) {
+                    'Microsoft 365'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled -and $group.MailEnabled) {
+                    'Mail-enabled security'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled) {
+                    'Security'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.MailEnabled) {
+                    'Distribution'
+                }
+                else {
+                    'N/A'
+                }
+
+                $report.Add([pscustomobject][ordered]@{
+                        DisplayName     = $group.DisplayName
+                        Id              = $group.Id
+                        GroupType       = $groupType
+                        MemberCount     = 0
+                        MailEnabled     = $group.MailEnabled
+                        SecurityEnabled = $group.SecurityEnabled
+                    }) | Out-Null
+            }
+
+            if ($Csv) {
+                $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
+                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-EmptyGroups.csv"
+                $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                Write-NCMessage "Empty groups report exported to $csvPath." -Level SUCCESS
+                $csvPath
+            }
+            else {
+                $report | Sort-Object DisplayName
+            }
+        }
+        catch {
+            Write-NCMessage "Unable to export empty Entra groups. $($_.Exception.Message)" -Level ERROR
+        }
+        finally {
+            Write-Progress -Activity "Checking empty Entra groups" -Completed
+            Restore-ProgressAndInfoPreferences
         }
     }
 }

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -66,7 +66,7 @@ function Add-EntraGroupDevice {
     end {
         if (-not $graphConnected) { return }
         if ($devices.Count -eq 0) {
-            Write-NCMessage "No devices specified" -Level WARNING
+            Write-NCMessage "No devices were specified." -Level WARNING
             return
         }
 
@@ -239,7 +239,7 @@ function Add-EntraGroupUser {
     end {
         if (-not $graphConnected) { return }
         if ($users.Count -eq 0) {
-            Write-NCMessage "No users specified" -Level WARNING
+            Write-NCMessage "No users were specified." -Level WARNING
             return
         }
 
@@ -458,7 +458,7 @@ function Export-DistributionGroups {
             foreach ($group in $groups) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-DistributionGroupMember -Identity $group.Identity -ResultSize Unlimited -ErrorAction Stop)
@@ -641,7 +641,7 @@ function Export-DynamicDistributionGroups {
             foreach ($group in $groups) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-DynamicDistributionGroupMember -Identity $group.Identity -ErrorAction Stop)
@@ -824,7 +824,7 @@ function Export-M365Group {
             foreach ($group in $groups) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-UnifiedGroupLinks -Identity $group.Identity -LinkType Member -ErrorAction Stop)
@@ -1098,7 +1098,7 @@ function Get-RoleGroupsMembers {
         foreach ($group in $roleGroups) {
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($group.Name)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($group.Name)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
             try {
                 $members = @(Get-RoleGroupMember -Identity $group.Identity -ErrorAction Stop)
@@ -1574,7 +1574,7 @@ function Export-EmptyEntraGroups {
             foreach ($group in $groups) {
                 $processedCount++
                 $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalGroups, 1)) * 100, 2)
-                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $members = @(Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop)
@@ -2043,7 +2043,7 @@ function Remove-EntraGroupDevice {
     end {
         if (-not $graphConnected) { return }
         if (-not $ClearAll.IsPresent -and $devices.Count -eq 0) {
-            Write-NCMessage "No devices specified" -Level WARNING
+            Write-NCMessage "No devices were specified." -Level WARNING
             return
         }
 
@@ -2299,7 +2299,7 @@ function Remove-EntraGroupUser {
     end {
         if (-not $graphConnected) { return }
         if (-not $ClearAll.IsPresent -and $users.Count -eq 0) {
-            Write-NCMessage "No users specified" -Level WARNING
+            Write-NCMessage "No users were specified." -Level WARNING
             return
         }
 

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -286,7 +286,7 @@ function Export-IntuneAppInventory {
             if ($FilterByPlatform -ne "All") {
                 $devices = $devices | Where-Object { $_.operatingSystem -like "$FilterByPlatform*" }
             }
-            Write-NCMessage "Devices retrieved: $($devices.Count)" -Level INFO
+            Write-NCMessage "Managed devices retrieved: $($devices.Count)" -Level INFO
 
             # Build app --> device mapping from Detected Apps
             $appDeviceMap = @{}
@@ -296,14 +296,14 @@ function Export-IntuneAppInventory {
                 $processed++
 
                 $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) - $processed / $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
                     $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET -ErrorAction Stop
                     
                     foreach ($app in ($deviceWithApps.detectedApps | Where-Object { $_.displayName -like $ApplicationName })) {
-                        Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) / $($app.displayName) ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                        Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) / $($app.displayName) - $processed / $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
                         if ($MinimumVersion -and $app.version) {
                             if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
                                 continue
@@ -342,7 +342,7 @@ function Export-IntuneAppInventory {
                         $processed--
 
                         $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
-                        Write-Progress -Activity "Reading Detected Apps" -Status "Waiting after rate limit ... ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                        Write-Progress -Activity "Reading Detected Apps" -Status "Waiting after rate limit ... - $processed / $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                         continue
                     }
@@ -425,7 +425,7 @@ function Export-IntuneAppInventory {
             }
 
             if (-not $rows -or $rows.Count -eq 0) {
-                Write-NCMessage "No matches found for '$ApplicationName' with the provided filters." -Level WARNING
+                Write-NCMessage "No applications matched '$ApplicationName' with the provided filters." -Level WARNING
                 return
             }
 
@@ -461,7 +461,7 @@ function Export-IntuneAppInventory {
                     $count = $_.Count
                     $versions = ($_.Group | Where-Object Version | Group-Object Version | Sort-Object Count -Descending | ForEach-Object { "{0} ({1})" -f $_.Name, $_.Count }) -join ", "
                     $publishers = ($_.Group | Where-Object Publisher | Group-Object Publisher | Sort-Object Count -Descending | Select-Object -First 3 | ForEach-Object { "{0} ({1})" -f $_.Name, $_.Count }) -join ", "
-                    "• {0}: {1} devices`n    Versions: {2}`n    Top publishers: {3}" -f $app, $count, ($(if ($versions) { $versions } else { 'n/a' })), ($(if ($publishers) { $publishers } else { 'n/a' }))
+                    "- {0}: {1} devices`n    Versions: {2}`n    Top publishers: {3}" -f $app, $count, ($(if ($versions) { $versions } else { 'n/a' })), ($(if ($publishers) { $publishers } else { 'n/a' }))
                 }
             }
 
@@ -589,17 +589,18 @@ function New-IntuneAppBasedGroup {
                 $devices = @($devices | Where-Object { $_.operatingSystem -like "$FilterByPlatform*" })
             }
 
-            Write-NCMessage "Found $($devices.Count) managed devices" -Level INFO
+            $managedDeviceLabel = if ($devices.Count -eq 1) { 'managed device' } else { 'managed devices' }
+            Write-NCMessage "Found $($devices.Count) $managedDeviceLabel" -Level INFO
 
             $appDeviceMap = @{}
             $processedDevices = 0
 
-            Write-NCMessage "Processing device applications ..." -Level INFO
+            Write-NCMessage "Scanning device applications ..." -Level INFO
             foreach ($device in $devices) {
                 $processedDevices++
 
                 $Percentage = [Math]::Round(($processedDevices / [Math]::Max($devices.Count, 1)) * 100, 2)
-                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) ($processedDevices of $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) - $processedDevices of $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$select=id,deviceName,operatingSystem,userPrincipalName,azureADDeviceId,azureActiveDirectoryDeviceId&`$expand=detectedApps"
@@ -608,7 +609,7 @@ function New-IntuneAppBasedGroup {
                     if ($deviceWithApps.detectedApps) {
                         foreach ($app in $deviceWithApps.detectedApps) {
                             if ($app.displayName -like $ApplicationName) {
-                                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) / $($app.displayName) ($processedDevices of $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) / $($app.displayName) - $processedDevices of $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                                 if ($MinimumVersion -and $app.version) {
                                     if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
@@ -622,17 +623,20 @@ function New-IntuneAppBasedGroup {
                                         Devices    = @()
                                         Versions   = @{}
                                         Publishers = @{}
+                                        DeviceIds  = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                                     }
                                 }
 
-                                $appDeviceMap[$appKey].Devices += [ordered]@{
-                                    DeviceId   = $device.id
-                                    DeviceName = $device.deviceName
-                                    Platform   = $device.operatingSystem
-                                    User       = $device.userPrincipalName
-                                    Version    = $app.version
-                                    Publisher  = $app.publisher
-                                    Source     = 'DetectedApps'
+                                if ($appDeviceMap[$appKey].DeviceIds.Add([string]$device.id)) {
+                                    $appDeviceMap[$appKey].Devices += [ordered]@{
+                                        DeviceId   = $device.id
+                                        DeviceName = $device.deviceName
+                                        Platform   = $device.operatingSystem
+                                        User       = $device.userPrincipalName
+                                        Version    = $app.version
+                                        Publisher  = $app.publisher
+                                        Source     = 'DetectedApps'
+                                    }
                                 }
 
                                 if ($app.version) {
@@ -701,11 +705,11 @@ function New-IntuneAppBasedGroup {
                                         Versions   = @{}
                                         Publishers = @{}
                                         AppType    = $appType
+                                        DeviceIds  = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
                                     }
                                 }
 
-                                $existingDevice = $appDeviceMap[$appKey].Devices | Where-Object { $_.DeviceId -eq $matchingDevice.id }
-                                if (-not $existingDevice) {
+                                if ($appDeviceMap[$appKey].DeviceIds.Add([string]$matchingDevice.id)) {
                                     $appDeviceMap[$appKey].Devices += [ordered]@{
                                         DeviceId     = $matchingDevice.id
                                         DeviceName   = $matchingDevice.deviceName
@@ -725,7 +729,7 @@ function New-IntuneAppBasedGroup {
                 Write-Verbose 'FilterByType applies only when deployment data is used. Skipping type filter for detected apps only.'
             }
 
-            Write-NCMessage "Processing groups for $($appDeviceMap.Count) applications ..." -Level INFO
+            Write-NCMessage "Preparing groups for $($appDeviceMap.Count) applications ..." -Level INFO
             $groupsCreated = 0
             $groupsUpdated = 0
             $totalDevicesProcessed = 0
@@ -798,14 +802,14 @@ function New-IntuneAppBasedGroup {
                 }
 
                 $Percentage = ($processedApps / [Math]::Max($groupTargets.Count, 1)) * 100
-                Write-Progress -Activity 'Processing App Groups' -Status "$appName / $groupName ($processedApps of $($groupTargets.Count) groups - $Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity 'Processing App Groups' -Status "$appName / $groupName - $processedApps of $($groupTargets.Count) groups - $Percentage%" -PercentComplete $Percentage
 
                 if ($DryRun.IsPresent) {
                     Write-NCMessage "[DRY RUN] Would create/update group: $groupName" -Level INFO
                     Write-NCMessage "Total devices with app matches: $deviceCount" -Level INFO
-                    Write-NCMessage "Devices to be added:" -Level INFO
+                    Write-Verbose "Devices to be added:"
                     foreach ($device in $appInfo.Devices) {
-                        Write-NCMessage "  • $($device.DeviceName) ($($device.Platform))" -Level INFO
+                        Write-Verbose "  - $($device.DeviceName) ($($device.Platform))"
                     }
 
                     if ($appInfo.Versions.Count -gt 0) {
@@ -841,7 +845,7 @@ function New-IntuneAppBasedGroup {
                         $Percentage = [Math]::Round(($processedMembers / [Math]::Max($uniqueDeviceIds.Count, 1)) * 100, 2)
                         $resolution = Resolve-NCIntuneManagedDeviceEntraMember -ManagedDevices $devices -DeviceId $deviceId
                         $deviceLabel = if ($resolution -and -not [string]::IsNullOrWhiteSpace($resolution.DeviceName)) { $resolution.DeviceName } else { [string]$deviceId }
-                        Write-Progress -Activity 'Resolving Entra Devices' -Status "$deviceLabel ($processedMembers of $($uniqueDeviceIds.Count) devices - $Percentage%)" -PercentComplete $Percentage
+                        Write-Progress -Activity 'Resolving Entra Devices' -Status "$deviceLabel - $processedMembers of $($uniqueDeviceIds.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                         if ($resolution) {
                             $memberIds += "https://graph.microsoft.com/v1.0/directoryObjects/$($resolution.EntraDeviceId)"
@@ -881,7 +885,8 @@ function New-IntuneAppBasedGroup {
                                     } | ConvertTo-Json -Depth 10
 
                                     Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($existingGroup.id)" -Method PATCH -Body $addBody -ContentType 'application/json'
-                                    Write-Verbose "Added batch of $($batch.Count) members"
+                                    $memberLabel = if ($batch.Count -eq 1) { 'member' } else { 'members' }
+                                    Write-Verbose "Added batch of $($batch.Count) $memberLabel"
                                 }
                             }
 
@@ -892,11 +897,11 @@ function New-IntuneAppBasedGroup {
 
                             Write-NCMessage "Updated group: $groupName (Added: $($deviceIdsToAdd.Count), Removed: $($deviceIdsToRemove.Count))" -Level SUCCESS
                             if ($deviceIdsToAdd.Count -gt 0) {
-                                Write-NCMessage "Added devices:" -Level INFO
+                                Write-Verbose "Added devices:"
                                 foreach ($deviceId in $deviceIdsToAdd) {
                                     $deviceInfo = $entraDevices | Where-Object { $_.EntraDeviceId -eq $deviceId } | Select-Object -First 1
                                     if ($deviceInfo) {
-                                        Write-NCMessage "  • $($deviceInfo.DeviceName)" -Level INFO
+                                        Write-Verbose "  - $($deviceInfo.DeviceName)"
                                     }
                                 }
                             }
@@ -933,13 +938,15 @@ function New-IntuneAppBasedGroup {
                                         } | ConvertTo-Json -Depth 10
 
                                         Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($newGroup.id)" -Method PATCH -Body $addMembersBody -ContentType 'application/json'
-                                        Write-Verbose "Added batch of $($batch.Count) members"
+                                        $memberLabel = if ($batch.Count -eq 1) { 'member' } else { 'members' }
+                                        Write-Verbose "Added batch of $($batch.Count) $memberLabel"
                                     }
 
-                                    Write-NCMessage "Added $($memberIds.Count) devices to group" -Level SUCCESS
-                                    Write-NCMessage "Added devices:" -Level INFO
+                                    $groupDeviceLabel = if ($memberIds.Count -eq 1) { 'device' } else { 'devices' }
+                                    Write-NCMessage "Added $($memberIds.Count) $groupDeviceLabel to group" -Level SUCCESS
+                                    Write-Verbose "Added devices:"
                                     foreach ($device in $entraDevices) {
-                                        Write-NCMessage "  • $($device.DeviceName)" -Level INFO
+                                        Write-Verbose "  - $($device.DeviceName)"
                                     }
                                 }
                                 catch {
@@ -961,12 +968,11 @@ function New-IntuneAppBasedGroup {
 
             Write-Progress -Activity 'Processing App Groups' -Completed
 
-            Write-NCMessage "APP-BASED GROUP CREATION SUMMARY" -Level INFO
-            Write-NCMessage "===================================" -Level INFO
-            Write-NCMessage "Applications matched: $($appDeviceMap.Count)" -Level INFO
-            Write-NCMessage "Total devices processed: $totalDevicesProcessed" -Level INFO
-            Write-NCMessage "Groups created: $groupsCreated" -Level INFO
-            Write-NCMessage "Groups updated: $groupsUpdated" -Level INFO
+            Add-EmptyLine
+            Write-NCMessage " - Applications matched: $($appDeviceMap.Count)" -Level INFO
+            Write-NCMessage " - Total devices processed: $totalDevicesProcessed" -Level INFO
+            Write-NCMessage " - Groups created: $groupsCreated" -Level INFO
+            Write-NCMessage " - Groups updated: $groupsUpdated" -Level INFO
 
             if ($DryRun.IsPresent) {
                 Write-NCMessage "[DRY RUN] No changes were made" -Level INFO
@@ -975,11 +981,12 @@ function New-IntuneAppBasedGroup {
             if ($appDeviceMap.Count -gt 0) {
                 Write-NCMessage "Top Applications by Device Count:" -Level INFO
                 $appDeviceMap.GetEnumerator() |
-                    Sort-Object { $_.Value.Devices.Count } -Descending |
+                    Sort-Object { if ($_.Value.DeviceIds) { $_.Value.DeviceIds.Count } else { $_.Value.Devices.Count } } -Descending |
                     Select-Object -First 10 |
                     ForEach-Object {
-                        $deviceCount = ($_.Value.Devices | Select-Object -Property DeviceId -Unique).Count
-                        Write-NCMessage "  • $($_.Key): $deviceCount devices" -Level INFO
+                        $deviceCount = if ($_.Value.DeviceIds) { $_.Value.DeviceIds.Count } else { ($_.Value.Devices | Select-Object -Property DeviceId -Unique).Count }
+                        $deviceLabel = if ($deviceCount -eq 1) { 'device' } else { 'devices' }
+                        Write-NCMessage "  - $($_.Key): $deviceCount $deviceLabel" -Level INFO
                     }
             }
 

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -4,6 +4,38 @@ using namespace System.Management.Automation
 # Nebula.Core: Intune helpers =======================================================================================================================
 
 function Get-IntuneProfileAssignmentsByGroup {
+    <#
+    .SYNOPSIS
+        Shows where an Entra group is used in Intune assignments.
+    .DESCRIPTION
+        Searches Intune device configurations, settings catalog policies, and apps for assignments that target
+        the specified Entra group. Supports lookup by group name or group ID, with optional filtering by profile
+        name or profile ID. Can also include parent groups that contain the requested group as a member.
+    .PARAMETER GroupName
+        Target Entra group display name. Accepts pipeline input.
+    .PARAMETER GroupId
+        Target Entra group object ID. Use this instead of GroupName.
+    .PARAMETER ProfileName
+        Optional profile or app display name filter.
+    .PARAMETER ProfileId
+        Optional filter for a specific Intune object ID.
+    .PARAMETER IncludeNestedGroups
+        Also match parent groups that include the requested Entra group.
+    .PARAMETER GridView
+        Show additional details in Out-GridView.
+    .PARAMETER Diagnostic
+        Include diagnostic columns in the returned objects.
+    .EXAMPLE
+        Get-IntuneProfileAssignmentsByGroup -GroupName "Windows 11 Pilot"
+    .EXAMPLE
+        Get-IntuneProfileAssignmentsByGroup -GroupId "00000000-0000-0000-0000-000000000000"
+    .EXAMPLE
+        "Windows 11 Pilot" | Get-IntuneProfileAssignmentsByGroup -GridView
+    .EXAMPLE
+        Get-IntuneProfileAssignmentsByGroup -GroupName "Intune - Reception" -IncludeNestedGroups
+    .EXAMPLE
+        Get-IntuneProfileAssignmentsByGroup -GroupName "Intune - Reception" -ProfileName "Zoom Workplace" -Diagnostic
+    #>
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
@@ -243,9 +275,9 @@ function Export-IntuneAppInventory {
                 return
             }
 
-            Write-Information "Starting app inventory reporting..." -InformationAction Continue
+            Write-NCMessage "Starting app inventory reporting ..." -Level INFO
 
-            # 1) Pull devices
+            # Pull devices
             $devicesUri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"
             if ($MaxDevices -gt 0) {
                 $devicesUri += "?`$top=$MaxDevices"
@@ -254,77 +286,95 @@ function Export-IntuneAppInventory {
             if ($FilterByPlatform -ne "All") {
                 $devices = $devices | Where-Object { $_.operatingSystem -like "$FilterByPlatform*" }
             }
-            Write-Information "✓ Devices retrieved: $($devices.Count)" -InformationAction Continue
+            Write-NCMessage "Devices retrieved: $($devices.Count)" -Level INFO
 
-            # 2) Build app->device mapping from Detected Apps
+            # Build app --> device mapping from Detected Apps
             $appDeviceMap = @{}
             $processed = 0
+
             foreach ($device in $devices) {
                 $processed++
-                Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
+                Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
                 try {
                     $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
                     $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET -ErrorAction Stop
+                    
                     foreach ($app in ($deviceWithApps.detectedApps | Where-Object { $_.displayName -like $ApplicationName })) {
+                        Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName) | App: $($app.displayName)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
                         if ($MinimumVersion -and $app.version) {
                             if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
                                 continue
                             }
                         }
+
                         $key = $app.displayName
                         if (-not $appDeviceMap.ContainsKey($key)) {
                             $appDeviceMap[$key] = [ordered]@{ Devices = @(); Versions = @{}; Publishers = @{} }
                         }
+                        
                         $appDeviceMap[$key].Devices += [ordered]@{
                             DeviceId   = $device.id
                             DeviceName = $device.deviceName
                             Platform   = $device.operatingSystem
                             User       = $device.userPrincipalName
                             Version    = $app.version
-                            Publisher  = $app.publisher
+                            # Publisher  = $app.publisher
                             Source     = "DetectedApps"
                         }
-                        if ($app.version)   { $appDeviceMap[$key].Versions[$app.version]   = ($appDeviceMap[$key].Versions[$app.version]   + 1) }
-                        if ($app.publisher) { $appDeviceMap[$key].Publishers[$app.publisher] = ($appDeviceMap[$key].Publishers[$app.publisher] + 1) }
+                        
+                        if ($app.version) { 
+                            $appDeviceMap[$key].Versions[$app.version] = ($appDeviceMap[$key].Versions[$app.version] + 1)
+                        }
+                        
+                        if ($app.publisher) { 
+                            $appDeviceMap[$key].Publishers[$app.publisher] = ($appDeviceMap[$key].Publishers[$app.publisher] + 1)
+                        }
                     }
                     Start-Sleep -Milliseconds 40
                 }
                 catch {
                     if ($_.Exception.Message -like "*429*") {
-                        Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                        Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
                         Start-Sleep -Seconds 60
                         $processed--
+                        Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Waiting after rate limit" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
                         continue
                     }
-                    Write-Warning "Error reading apps for $($device.deviceName): $($_.Exception.Message)"
+                    Write-NCMessage "Error reading apps for $($device.deviceName): $($_.Exception.Message)" -Level WARNING
                 }
             }
             Write-Progress -Activity "Reading Detected Apps" -Completed
 
-            # 3) Optionally incorporate deployment statuses (broadens coverage)
+            # Optionally incorporate deployment statuses (broadens coverage)
             if ($IncludeDeployedApps) {
-                Write-Information "Including deployed apps device status..." -InformationAction Continue
+                Write-NCMessage "Including deployed apps device status ..." -Level INFO
                 $appsUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
                 $allApps = @(Invoke-NCGraphAllPagesCore -Uri $appsUri)
+                
                 foreach ($app in $allApps | Where-Object { $_.displayName -like $ApplicationName }) {
                     $appType = Get-NCIntuneAppTypeFromODataType -ODataType $app.'@odata.type'
                     if ($FilterByType -ne "All" -and $appType -ne $FilterByType) {
                         continue
                     }
+
                     $statusUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/deviceStatuses"
                     $statuses = @(Invoke-NCGraphAllPagesCore -Uri $statusUri)
+                    
                     foreach ($s in $statuses) {
                         if ($OnlySuccessfulInstalls -and $s.installState -ne "installed") {
                             continue
                         }
+
                         $d = $devices | Where-Object { $_.id -eq $s.deviceId } | Select-Object -First 1
                         if (-not $d) {
                             continue
                         }
+
                         $key = $app.displayName
                         if (-not $appDeviceMap.ContainsKey($key)) {
                             $appDeviceMap[$key] = [ordered]@{ Devices = @(); Versions = @{}; Publishers = @{} }
                         }
+
                         # Avoid duplicates for the same device/app when DetectedApps already included it
                         $exists = $appDeviceMap[$key].Devices | Where-Object { $_.DeviceId -eq $d.id }
                         if (-not $exists) {
@@ -334,9 +384,9 @@ function Export-IntuneAppInventory {
                                 Platform     = $d.operatingSystem
                                 User         = $d.userPrincipalName
                                 Version      = $null
-                                Publisher    = $null
-                                InstallState = $s.installState
-                                AppType      = $appType
+                                # Publisher    = $null
+                                # InstallState = $s.installState
+                                # AppType      = $appType
                                 Source       = "DeploymentStatus"
                             }
                         }
@@ -344,62 +394,62 @@ function Export-IntuneAppInventory {
                 }
             }
 
-            # 4) Optional app type filter when only Detected Apps were used
+            # Optional app type filter when only Detected Apps were used
             if (-not $IncludeDeployedApps -and $FilterByType -ne "All") {
-                Write-Verbose "FilterByType applies only when -IncludeDeployedApps is used. Skipping type filter for Detected Apps only."
+                Write-NCMessage "FilterByType applies only when -IncludeDeployedApps is used. Skipping type filter for Detected Apps only." -Level VERBOSE
             }
 
-            # 5) Build flat rows
+            # Build flat rows
             $rows = @()
             foreach ($appName in $appDeviceMap.Keys) {
                 foreach ($dev in $appDeviceMap[$appName].Devices) {
                     $rows += [pscustomobject]@{
                         AppName      = $appName
                         Version      = $dev.Version
-                        Publisher    = $dev.Publisher
-                        AppType      = $dev.AppType
+                        # Publisher    = $dev.Publisher
+                        # AppType      = $dev.AppType
                         DeviceName   = $dev.DeviceName
                         DeviceId     = $dev.DeviceId
                         Platform     = $dev.Platform
                         User         = $dev.User
-                        InstallState = $dev.InstallState
+                        # InstallState = $dev.InstallState
                         Source       = $dev.Source
                     }
                 }
             }
 
             if (-not $rows -or $rows.Count -eq 0) {
-                Write-Warning "No matches found for '$ApplicationName' with the provided filters."
+                Write-NCMessage "No matches found for '$ApplicationName' with the provided filters." -Level WARNING
                 return
             }
 
-            # 6) Console table output
+            # Console table output
             $rows | Sort-Object AppName, DeviceName | Format-Table -AutoSize AppName, Version, Publisher, AppType, DeviceName, Platform, User, InstallState, Source
 
-            # 7) Optional exports
+            # Optional exports
             if ($OutputCsvPath) {
                 try {
                     $rows | Sort-Object AppName, DeviceName | Export-Csv -Path $OutputCsvPath -NoTypeInformation -Encoding UTF8
-                    Write-Information "✓ CSV exported to $OutputCsvPath" -InformationAction Continue
+                    Write-NCMessage "CSV exported to $OutputCsvPath" -Level SUCCESS
                 }
                 catch {
-                    Write-Warning "Failed to export CSV: $($_.Exception.Message)"
+                    Write-NCMessage "Failed to export CSV: $($_.Exception.Message)" -Level WARNING
                 }
             }
 
             if ($OutputJsonPath) {
                 try {
                     $rows | ConvertTo-Json -Depth 5 | Out-File -FilePath $OutputJsonPath -Encoding UTF8
-                    Write-Information "✓ JSON exported to $OutputJsonPath" -InformationAction Continue
+                    Write-NCMessage "JSON exported to $OutputJsonPath" -Level SUCCESS
                 }
                 catch {
-                    Write-Warning "Failed to export JSON: $($_.Exception.Message)"
+                    Write-NCMessage "Failed to export JSON: $($_.Exception.Message)" -Level WARNING
                 }
             }
 
-            # 8) Optional per-app pivot/summary
+            # Optional per-app pivot/summary
             if ($PivotSummary) {
-                Write-Host "`n=== SUMMARY BY APPLICATION ===" -ForegroundColor Cyan
+                Write-NCMessage "`n=== SUMMARY BY APPLICATION ===" -Level INFO
                 $rows | Group-Object AppName | Sort-Object Count -Descending | ForEach-Object {
                     $app = $_.Name
                     $count = $_.Count
@@ -408,12 +458,537 @@ function Export-IntuneAppInventory {
                     "• {0}: {1} devices`n    Versions: {2}`n    Top publishers: {3}" -f $app, $count, ($(if ($versions) { $versions } else { 'n/a' })), ($(if ($publishers) { $publishers } else { 'n/a' }))
                 }
             }
-
-            Write-Information "`n🎉 Reporting completed successfully!" -InformationAction Continue
         }
         catch {
-            Write-Error "Script execution failed: $($_.Exception.Message)"
+            Write-NCMessage "Script execution failed: $($_.Exception.Message)" -Level ERROR
             exit 1
+        }
+    }
+}
+
+function New-IntuneAppBasedGroup {
+    <#
+    .SYNOPSIS
+        Creates Entra groups based on apps installed on Intune-managed devices.
+    .DESCRIPTION
+        Queries Intune-managed devices, discovers matching apps through detected apps and deployed
+        app status data, and creates or updates Entra security groups populated with the matching
+        Entra device objects. Use this for dynamic device targeting based on installed software.
+    .PARAMETER ApplicationName
+        Application name or wildcard pattern to match.
+    .PARAMETER GroupName
+        Explicit full group name to use instead of generating one from prefix and suffix.
+        When supplied, all matching devices are collected into a single group target.
+    .PARAMETER GroupPrefix
+        Prefix applied to generated group names.
+    .PARAMETER GroupSuffix
+        Suffix applied to generated group names.
+    .PARAMETER UpdateExisting
+        Update matching groups instead of skipping them when they already exist.
+    .PARAMETER MinimumVersion
+        Minimum application version to keep in the result set.
+    .PARAMETER FilterByType
+        Optional app type filter for deployment-status coverage.
+    .PARAMETER FilterByPlatform
+        Optional device platform filter.
+    .PARAMETER OnlySuccessfulInstalls
+        When deployment data is used, keep only successful installs.
+    .PARAMETER DryRun
+        Preview changes without creating or updating groups.
+    .PARAMETER MaxDevices
+        Maximum number of devices to process. Use 0 for all devices.
+    .EXAMPLE
+        New-IntuneAppBasedGroup -ApplicationName "TeamViewer"
+    .EXAMPLE
+        New-IntuneAppBasedGroup -ApplicationName "TeamViewer" -GroupName "Devices - TeamViewer"
+    .EXAMPLE
+        New-IntuneAppBasedGroup -ApplicationName "Microsoft*" -GroupPrefix "SW-" -GroupSuffix "-Installed"
+    .EXAMPLE
+        New-IntuneAppBasedGroup -ApplicationName "Chrome" -MinimumVersion "120.0" -UpdateExisting
+    .EXAMPLE
+        New-IntuneAppBasedGroup -ApplicationName "*" -FilterByType Win32 -DryRun
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('SearchText', 'Name', 'DisplayName', 'Query', 'AppName')]
+        [string]$ApplicationName,
+
+        [string]$GroupName,
+        [string]$GroupPrefix = 'Devices-With-',
+        [string]$GroupSuffix = '',
+        [switch]$UpdateExisting,
+        [string]$MinimumVersion,
+
+        [ValidateSet('Win32', 'Store', 'LOB', 'Web', 'iOS', 'Android', 'macOS', 'All')]
+        [string]$FilterByType = 'All',
+
+        [ValidateSet('Windows', 'iOS', 'Android', 'macOS', 'All')]
+        [string]$FilterByPlatform = 'All',
+
+        [switch]$OnlySuccessfulInstalls,
+        [switch]$DryRun,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$MaxDevices = 0
+    )
+
+    begin {
+        $graphConnected = $null
+    }
+
+    process {
+        try {
+            if ($null -eq $graphConnected) {
+                $graphConnected = Test-MgGraphConnection -Scopes @(
+                    'DeviceManagementManagedDevices.Read.All',
+                    'DeviceManagementApps.Read.All',
+                    'Group.ReadWrite.All',
+                    'Directory.Read.All'
+                ) -EnsureExchangeOnline:$false
+                if (-not $graphConnected) {
+                    Add-EmptyLine
+                    Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                    return
+                }
+
+                if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                    Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+                    return
+                }
+            }
+
+            if ([string]::IsNullOrWhiteSpace($ApplicationName)) {
+                Write-NCMessage "ApplicationName cannot be empty." -Level WARNING
+                return
+            }
+
+            $useExplicitGroupName = -not [string]::IsNullOrWhiteSpace($GroupName)
+            if ($useExplicitGroupName -and ($PSBoundParameters.ContainsKey('GroupPrefix') -or $PSBoundParameters.ContainsKey('GroupSuffix'))) {
+                Write-NCMessage 'GroupName was supplied; GroupPrefix and GroupSuffix will be ignored.' -Level VERBOSE
+            }
+
+            Write-NCMessage "Starting app-based group creation process ..." -Level INFO
+
+            Write-NCMessage "Retrieving managed devices ..." -Level INFO
+            $devicesUri = 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices'
+            if ($MaxDevices -gt 0) {
+                $devicesUri += "?`$top=$MaxDevices"
+            }
+
+            $devices = @(Invoke-NCGraphAllPagesCore -Uri $devicesUri)
+            if ($FilterByPlatform -ne 'All') {
+                $devices = @($devices | Where-Object { $_.operatingSystem -like "$FilterByPlatform*" })
+            }
+
+            Write-NCMessage "Found $($devices.Count) managed devices" -Level INFO
+
+            $appDeviceMap = @{}
+            $processedDevices = 0
+
+            Write-NCMessage "Processing device applications ..." -Level INFO
+            foreach ($device in $devices) {
+                $processedDevices++
+                Write-Progress -Activity 'Processing Devices' -Status "$processedDevices of $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName)" -PercentComplete (($processedDevices / [Math]::Max($devices.Count, 1)) * 100)
+
+                try {
+                    $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
+                    $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET
+
+                    if ($deviceWithApps.detectedApps) {
+                        foreach ($app in $deviceWithApps.detectedApps) {
+                            if ($app.displayName -like $ApplicationName) {
+                                Write-Progress -Activity 'Processing Devices' -Status "$processedDevices of $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName) | App: $($app.displayName)" -PercentComplete (($processedDevices / [Math]::Max($devices.Count, 1)) * 100)
+
+                                if ($MinimumVersion -and $app.version) {
+                                    if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
+                                        continue
+                                    }
+                                }
+
+                                $appKey = $app.displayName
+                                if (-not $appDeviceMap.ContainsKey($appKey)) {
+                                    $appDeviceMap[$appKey] = @{
+                                        Devices    = @()
+                                        Versions   = @{}
+                                        Publishers = @{}
+                                    }
+                                }
+
+                                $appDeviceMap[$appKey].Devices += [ordered]@{
+                                    DeviceId   = $device.id
+                                    DeviceName = $device.deviceName
+                                    Platform   = $device.operatingSystem
+                                    User       = $device.userPrincipalName
+                                    Version    = $app.version
+                                    Publisher  = $app.publisher
+                                    Source     = 'DetectedApps'
+                                }
+
+                                if ($app.version) {
+                                    if ($appDeviceMap[$appKey].Versions.ContainsKey($app.version)) {
+                                        $appDeviceMap[$appKey].Versions[$app.version]++
+                                    }
+                                    else {
+                                        $appDeviceMap[$appKey].Versions[$app.version] = 1
+                                    }
+                                }
+
+                                if ($app.publisher) {
+                                    if ($appDeviceMap[$appKey].Publishers.ContainsKey($app.publisher)) {
+                                        $appDeviceMap[$appKey].Publishers[$app.publisher]++
+                                    }
+                                    else {
+                                        $appDeviceMap[$appKey].Publishers[$app.publisher] = 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Start-Sleep -Milliseconds 50
+                }
+                catch {
+                    if ($_.Exception.Message -like '*429*') {
+                        Write-NCMessage "Rate limit hit, waiting 60 seconds ..." -Level INFO
+                        Start-Sleep -Seconds 60
+                        $processedDevices--
+                        continue
+                    }
+
+                    Write-NCMessage "Error processing device $($device.deviceName): $($_.Exception.Message)" -Level WARNING
+                }
+            }
+
+            Write-Progress -Activity 'Processing Devices' -Completed
+
+            if ($FilterByType -ne 'All' -or $OnlySuccessfulInstalls.IsPresent) {
+                Write-NCMessage "Retrieving deployed application data ..." -Level INFO
+                $appsUri = 'https://graph.microsoft.com/beta/deviceAppManagement/mobileApps'
+                $deployedApps = @(Invoke-NCGraphAllPagesCore -Uri $appsUri)
+
+                foreach ($app in $deployedApps) {
+                    if ($app.displayName -like $ApplicationName) {
+                        $appType = Get-NCIntuneAppTypeFromODataType -ODataType ([string]$app.'@odata.type')
+                        if ($FilterByType -ne 'All' -and $appType -ne $FilterByType) {
+                            continue
+                        }
+
+                        $statusUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/deviceStatuses"
+                        $deviceStatuses = @(Invoke-NCGraphAllPagesCore -Uri $statusUri)
+
+                        foreach ($status in $deviceStatuses) {
+                            if ($OnlySuccessfulInstalls.IsPresent -and $status.installState -ne 'installed') {
+                                continue
+                            }
+
+                            $matchingDevice = $devices | Where-Object { $_.id -eq $status.deviceId } | Select-Object -First 1
+                            if ($matchingDevice) {
+                                $appKey = $app.displayName
+                                if (-not $appDeviceMap.ContainsKey($appKey)) {
+                                    $appDeviceMap[$appKey] = @{
+                                        Devices    = @()
+                                        Versions   = @{}
+                                        Publishers = @{}
+                                        AppType    = $appType
+                                    }
+                                }
+
+                                $existingDevice = $appDeviceMap[$appKey].Devices | Where-Object { $_.DeviceId -eq $matchingDevice.id }
+                                if (-not $existingDevice) {
+                                    $appDeviceMap[$appKey].Devices += [ordered]@{
+                                        DeviceId     = $matchingDevice.id
+                                        DeviceName   = $matchingDevice.deviceName
+                                        Platform     = $matchingDevice.operatingSystem
+                                        User         = $matchingDevice.userPrincipalName
+                                        InstallState = $status.installState
+                                        AppType      = $appType
+                                        Source       = 'DeploymentStatus'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            elseif ($FilterByType -ne 'All') {
+                Write-NCMessage 'FilterByType applies only when deployment data is used. Skipping type filter for detected apps only.' -Level VERBOSE
+            }
+
+            Write-NCMessage "Processing groups for $($appDeviceMap.Count) applications ..." -Level INFO
+            $groupsCreated = 0
+            $groupsUpdated = 0
+            $totalDevicesProcessed = 0
+            $groupTargets = @()
+            if ($useExplicitGroupName) {
+                $allDevices = @($appDeviceMap.Values | ForEach-Object { $_.Devices } | Where-Object { $_ })
+                $allVersions = @{}
+                $allPublishers = @{}
+                foreach ($appInfo in $appDeviceMap.Values) {
+                    foreach ($version in $appInfo.Versions.Keys) {
+                        if (-not $allVersions.ContainsKey($version)) {
+                            $allVersions[$version] = 0
+                        }
+                        $allVersions[$version] += $appInfo.Versions[$version]
+                    }
+                    foreach ($publisher in $appInfo.Publishers.Keys) {
+                        if (-not $allPublishers.ContainsKey($publisher)) {
+                            $allPublishers[$publisher] = 0
+                        }
+                        $allPublishers[$publisher] += $appInfo.Publishers[$publisher]
+                    }
+                }
+
+                $groupTargets += [ordered]@{
+                    AppName    = if ($appDeviceMap.Keys.Count -gt 1) { 'Matching apps' } else { $appDeviceMap.Keys | Select-Object -First 1 }
+                    Devices    = $allDevices
+                    Versions   = $allVersions
+                    Publishers = $allPublishers
+                    GroupName  = $GroupName
+                    GroupScope = 'ExplicitGroupName'
+                }
+            }
+            else {
+                foreach ($appName in $appDeviceMap.Keys) {
+                    $groupTargets += [ordered]@{
+                        AppName    = $appName
+                        Devices    = $appDeviceMap[$appName].Devices
+                        Versions   = $appDeviceMap[$appName].Versions
+                        Publishers = $appDeviceMap[$appName].Publishers
+                        GroupName  = $null
+                        GroupScope = 'PerApp'
+                    }
+                }
+            }
+
+            $processedApps = 0
+            foreach ($target in $groupTargets) {
+                $processedApps++
+                $appName = $target.AppName
+                $appInfo = $target
+                $uniqueDevices = $appInfo.Devices | Select-Object -Property DeviceId -Unique
+                $deviceCount = $uniqueDevices.Count
+
+                if ($deviceCount -eq 0) {
+                    continue
+                }
+
+                if ($useExplicitGroupName) {
+                    $groupName = Get-NCIntuneAppBasedGroupName -GroupName $GroupName
+                    $groupDescription = 'Devices matching selected Intune apps (Created via Nebula.Core)'
+                }
+                else {
+                    $groupName = Get-NCIntuneAppBasedGroupName -AppName $appName -GroupPrefix $GroupPrefix -GroupSuffix $GroupSuffix
+                    $groupDescription = "Devices with $appName installed (Created via Nebula.Core)"
+                }
+                Write-Progress -Activity 'Processing App Groups' -Status "$processedApps of $($groupTargets.Count) groups" -CurrentOperation "App: $appName | Group: $groupName" -PercentComplete (($processedApps / [Math]::Max($groupTargets.Count, 1)) * 100)
+                if ($DryRun.IsPresent) {
+                    Write-NCMessage "[DRY RUN] Would create/update group: $groupName" -Level INFO
+                    Write-NCMessage "Total devices with app matches: $deviceCount" -Level INFO
+                    Write-NCMessage "Devices to be added:" -Level INFO
+                    foreach ($device in $appInfo.Devices) {
+                        Write-NCMessage "  • $($device.DeviceName) ($($device.Platform))" -Level INFO
+                    }
+
+                    if ($appInfo.Versions.Count -gt 0) {
+                        Write-NCMessage "Versions found: $($appInfo.Versions.Keys -join ', ')" -Level INFO
+                    }
+
+                    $totalDevicesProcessed += $deviceCount
+                    continue
+                }
+
+                $existingGroup = $null
+                try {
+                    $groupFilter = "displayName eq '$($groupName.Replace("'", "''"))'"
+                    $existingGroup = Get-MgGroup -Filter $groupFilter -All -ErrorAction Stop | Select-Object -First 1
+                }
+                catch {
+                    Write-NCMessage "No existing group found with name: $groupName" -Level WARNING
+                }
+
+                if ($existingGroup -and -not $UpdateExisting.IsPresent) {
+                    Write-NCMessage "Group '$groupName' already exists. Use -UpdateExisting to update it." -Level WARNING
+                    continue
+                }
+
+                $memberIds = @()
+                $entraDevices = @()
+                $processedMembers = 0
+
+                foreach ($device in $uniqueDevices) {
+                    $processedMembers++
+
+                    try {
+                        $intuneDevice = $devices | Where-Object { $_.id -eq $device.DeviceId } | Select-Object -First 1
+                        $deviceLabel = if ($intuneDevice -and -not [string]::IsNullOrWhiteSpace($intuneDevice.deviceName)) {
+                            $intuneDevice.deviceName
+                        }
+                        else {
+                            $device.DeviceId
+                        }
+
+                        Write-Progress -Activity 'Resolving Entra Devices' -Status "$processedMembers of $($uniqueDevices.Count) devices" -CurrentOperation "Device: $deviceLabel" -PercentComplete (($processedMembers / [Math]::Max($uniqueDevices.Count, 1)) * 100)
+
+                        if ($intuneDevice -and $intuneDevice.azureADDeviceId) {
+                            $filter = "deviceId eq '$($intuneDevice.azureADDeviceId)'"
+                            $entraDeviceUri = "https://graph.microsoft.com/v1.0/devices?`$filter=$filter"
+                            $entraDeviceResponse = Invoke-MgGraphRequest -Uri $entraDeviceUri -Method GET
+
+                            if ($entraDeviceResponse.value -and $entraDeviceResponse.value.Count -gt 0) {
+                                $entraDevice = $entraDeviceResponse.value[0]
+                                $memberIds += "https://graph.microsoft.com/v1.0/directoryObjects/$($entraDevice.id)"
+                                $entraDevices += @{
+                                    IntuneDeviceId = $device.DeviceId
+                                    EntraDeviceId  = $entraDevice.id
+                                    DeviceName     = $intuneDevice.deviceName
+                                }
+                                Write-NCMessage "Found Entra ID device: $($intuneDevice.deviceName) -> $($entraDevice.id)" -Level VERBOSE
+                            }
+                            else {
+                                Write-NCMessage "Device not found in Entra ID: $($intuneDevice.deviceName) (Azure AD Device ID: $($intuneDevice.azureADDeviceId))" -Level WARNING
+                            }
+                        }
+                        else {
+                            Write-NCMessage "No Azure AD Device ID for: $($intuneDevice.deviceName)" -Level WARNING
+                        }
+                    }
+                    catch {
+                        Write-NCMessage "Error looking up Entra ID device for $($intuneDevice.deviceName): $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+
+                Write-Progress -Activity 'Resolving Entra Devices' -Completed
+
+                if ($existingGroup -and $UpdateExisting.IsPresent) {
+                    if ($PSCmdlet.ShouldProcess($groupName, 'Update group members')) {
+                        try {
+                            $currentMembersUri = "https://graph.microsoft.com/v1.0/groups/$($existingGroup.id)/members"
+                            $currentMembers = @(Invoke-NCGraphAllPagesCore -Uri $currentMembersUri)
+                            $currentMemberIds = $currentMembers | ForEach-Object { $_.id }
+
+                            $entraDeviceIds = $entraDevices | ForEach-Object { $_.EntraDeviceId }
+                            $deviceIdsToAdd = $entraDeviceIds | Where-Object { $_ -notin $currentMemberIds }
+                            $deviceIdsToRemove = $currentMemberIds | Where-Object { $_ -notin $entraDeviceIds }
+
+                            if ($deviceIdsToAdd.Count -gt 0) {
+                                $batchSize = 20
+                                for ($i = 0; $i -lt $deviceIdsToAdd.Count; $i += $batchSize) {
+                                    $batch = $deviceIdsToAdd[$i..([Math]::Min($i + $batchSize - 1, $deviceIdsToAdd.Count - 1))]
+                                    $addBody = @{
+                                        'members@odata.bind' = $batch | ForEach-Object {
+                                            "https://graph.microsoft.com/v1.0/directoryObjects/$_"
+                                        }
+                                    } | ConvertTo-Json -Depth 10
+
+                                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($existingGroup.id)" -Method PATCH -Body $addBody -ContentType 'application/json'
+                                    Write-Verbose "Added batch of $($batch.Count) members"
+                                }
+                            }
+
+                            foreach ($memberId in $deviceIdsToRemove) {
+                                $removeUri = "https://graph.microsoft.com/v1.0/groups/$($existingGroup.id)/members/$memberId/`$ref"
+                                Invoke-MgGraphRequest -Uri $removeUri -Method DELETE
+                            }
+
+                            Write-NCMessage "Updated group: $groupName (Added: $($deviceIdsToAdd.Count), Removed: $($deviceIdsToRemove.Count))" -Level SUCCESS
+                            if ($deviceIdsToAdd.Count -gt 0) {
+                                Write-NCMessage "Added devices:" -Level INFO
+                                foreach ($deviceId in $deviceIdsToAdd) {
+                                    $deviceInfo = $entraDevices | Where-Object { $_.EntraDeviceId -eq $deviceId } | Select-Object -First 1
+                                    if ($deviceInfo) {
+                                        Write-NCMessage "  • $($deviceInfo.DeviceName)" -Level INFO
+                                    }
+                                }
+                            }
+
+                            $groupsUpdated++
+                        }
+                        catch {
+                            Write-NCMessage "Failed to update group: $($_.Exception.Message)" -Level ERROR
+                        }
+                    }
+                }
+                else {
+                    if ($PSCmdlet.ShouldProcess($groupName, 'Create new group')) {
+                        try {
+                            $groupBody = @{
+                                displayName     = $groupName
+                                mailEnabled     = $false
+                                mailNickname    = ($groupName -replace '[^a-zA-Z0-9]', '')
+                                securityEnabled = $true
+                                description     = $groupDescription
+                            } | ConvertTo-Json -Depth 10
+
+                            $newGroup = Invoke-MgGraphRequest -Uri 'https://graph.microsoft.com/v1.0/groups' -Method POST -Body $groupBody -ContentType 'application/json'
+                            Write-NCMessage "Created group: $groupName" -Level SUCCESS
+                            Write-NCMessage "Group ID: $($newGroup.id)" -Level INFO
+
+                            if ($memberIds.Count -gt 0) {
+                                try {
+                                    $batchSize = 20
+                                    for ($i = 0; $i -lt $memberIds.Count; $i += $batchSize) {
+                                        $batch = $memberIds[$i..([Math]::Min($i + $batchSize - 1, $memberIds.Count - 1))]
+                                        $addMembersBody = @{
+                                            'members@odata.bind' = $batch
+                                        } | ConvertTo-Json -Depth 10
+
+                                        Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($newGroup.id)" -Method PATCH -Body $addMembersBody -ContentType 'application/json'
+                                        Write-Verbose "Added batch of $($batch.Count) members"
+                                    }
+
+                                    Write-NCMessage "Added $($memberIds.Count) devices to group" -Level SUCCESS
+                                    Write-NCMessage "Added devices:" -Level INFO
+                                    foreach ($device in $entraDevices) {
+                                        Write-NCMessage "  • $($device.DeviceName)" -Level INFO
+                                    }
+                                }
+                                catch {
+                                    Write-NCMessage "Group created but failed to add members: $($_.Exception.Message)" -Level ERROR
+                                }
+                            }
+
+                            $groupsCreated++
+                        }
+                        catch {
+                            Write-NCMessage "Failed to create group: $($_.Exception.Message)" -Level ERROR
+                            Write-NCMessage "Group body: $groupBody" -Level VERBOSE
+                        }
+                    }
+                }
+
+                $totalDevicesProcessed += $deviceCount
+            }
+
+            Write-Progress -Activity 'Processing App Groups' -Completed
+
+            Write-NCMessage "APP-BASED GROUP CREATION SUMMARY" -Level INFO
+            Write-NCMessage "===================================" -Level INFO
+            Write-NCMessage "Applications matched: $($appDeviceMap.Count)" -Level INFO
+            Write-NCMessage "Total devices processed: $totalDevicesProcessed" -Level INFO
+            Write-NCMessage "Groups created: $groupsCreated" -Level INFO
+            Write-NCMessage "Groups updated: $groupsUpdated" -Level INFO
+
+            if ($DryRun.IsPresent) {
+                Write-NCMessage "[DRY RUN] No changes were made" -Level INFO
+            }
+
+            if ($appDeviceMap.Count -gt 0) {
+                Write-NCMessage "Top Applications by Device Count:" -Level INFO
+                $appDeviceMap.GetEnumerator() |
+                    Sort-Object { $_.Value.Devices.Count } -Descending |
+                    Select-Object -First 10 |
+                    ForEach-Object {
+                        $deviceCount = ($_.Value.Devices | Select-Object -Property DeviceId -Unique).Count
+                        Write-NCMessage "  • $($_.Key): $deviceCount devices" -Level INFO
+                    }
+            }
+
+            Write-NCMessage "App-based group creation completed successfully." -Level SUCCESS
+        }
+        catch {
+            Write-NCMessage "Script execution failed: $($_.Exception.Message)" -Level ERROR
+            return
         }
     }
 }

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Intune ===============================================================================================================================
+# Nebula.Core: Intune helpers =======================================================================================================================
 
 function Get-IntuneProfileAssignmentsByGroup {
     [CmdletBinding(DefaultParameterSetName = 'ByName')]
@@ -55,142 +55,6 @@ function Search-IntuneProfileLocation {
 
     begin {
         $graphConnected = $null
-
-        function Invoke-NCGraphCollectionRequestLocal {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $true)]
-                [string]$Uri
-            )
-
-            $items = [System.Collections.Generic.List[object]]::new()
-            $nextUri = $Uri
-
-            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
-
-                $pageItems = @()
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('value')) {
-                        $value = $response['value']
-                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                            foreach ($entry in $value) {
-                                if ($null -ne $entry) { $pageItems += $entry }
-                            }
-                        }
-                        elseif ($null -ne $value) {
-                            $pageItems = @($value)
-                        }
-                    }
-                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
-                        $pageItems = @($response)
-                    }
-                }
-                elseif ($response -is [System.Array]) {
-                    $pageItems = @($response)
-                }
-                elseif ($response.PSObject.Properties.Name -contains 'value') {
-                    $value = $response.value
-                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                        foreach ($entry in $value) {
-                            if ($null -ne $entry) { $pageItems += $entry }
-                        }
-                    }
-                    elseif ($null -ne $value) {
-                        $pageItems = @($value)
-                    }
-                }
-                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
-                    $pageItems = @($response)
-                }
-
-                foreach ($item in $pageItems) {
-                    $items.Add($item) | Out-Null
-                }
-
-                $nextLink = $null
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('@odata.nextLink')) {
-                        $nextLink = [string]$response['@odata.nextLink']
-                    }
-                }
-                else {
-                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
-                    if ($nextLinkProperty) {
-                        $nextLink = [string]$nextLinkProperty.Value
-                    }
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
-                    $nextUri = $nextLink
-                }
-                else {
-                    $nextUri = $null
-                }
-            }
-
-            return $items.ToArray()
-        }
-
-        function Get-NCIntuneItemName {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
-                $property = $Item.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    return [string]$property.Value
-                }
-            }
-
-            return $null
-        }
-
-        function Get-NCIntuneItemId {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            foreach ($propertyName in @('id', 'Id')) {
-                $property = $Item.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    return [string]$property.Value
-                }
-            }
-
-            return $null
-        }
-
-        function Get-NCIntuneItemODataType {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            $odataProperty = $Item.PSObject.Properties['@odata.type']
-            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
-                return [string]$odataProperty.Value
-            }
-
-            $additionalProperties = $Item.PSObject.Properties['AdditionalProperties']
-            if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
-                return [string]$additionalProperties.Value['@odata.type']
-            }
-
-            return $null
-        }
     }
 
     process {
@@ -236,7 +100,7 @@ function Search-IntuneProfileLocation {
 
             foreach ($endpointUri in $endpoint.Uris) {
                 try {
-                    $items = @(Invoke-NCGraphCollectionRequestLocal -Uri $endpointUri)
+                    $items = @(Invoke-NCGraphCollectionRequest -Uri $endpointUri)
                     $queried = $true
                     break
                 }
@@ -296,640 +160,260 @@ function Search-IntuneProfileLocation {
     }
 }
 
-function Search-IntuneRawEndpoint {
+function Export-IntuneAppInventory {
     <#
     .SYNOPSIS
-        Probes raw Intune Microsoft Graph endpoints and filters results by profile name.
+        Reports Intune-managed devices that have matching applications installed.
     .DESCRIPTION
-        Connects to Microsoft Graph, queries a curated set of Intune deviceManagement endpoints,
-        and returns any items whose common identifying properties or object ID match the provided search text.
-        Use this as a low-level discovery tool when a profile is not found by the higher-level
-        Intune helper functions.
-    .PARAMETER SearchText
-        Text to search for in the returned profile names.
-    .PARAMETER Endpoint
-        Optional custom endpoint URIs to probe. When omitted, a built-in curated list is used.
-    .PARAMETER Exact
-        Match the profile name exactly instead of using a contains search.
-    .PARAMETER GridView
-        Show the results in Out-GridView instead of returning objects.
+        Connects to Microsoft Graph, scans managed devices for detected apps, and can optionally
+        enrich the report with deployed app device status information. The output is report-friendly
+        and can also be exported to CSV and/or JSON.
+    .PARAMETER ApplicationName
+        Application name or wildcard pattern to match. Accepts pipeline input.
+    .PARAMETER MinimumVersion
+        Minimum application version to keep in the report.
+    .PARAMETER FilterByType
+        Optional app type filter when deployed app data is included.
+    .PARAMETER FilterByPlatform
+        Optional device platform filter.
+    .PARAMETER OnlySuccessfulInstalls
+        When deployed app data is included, keep only successful installs.
+    .PARAMETER IncludeDeployedApps
+        Also query deployed app device statuses in addition to detected apps.
+    .PARAMETER MaxDevices
+        Maximum number of devices to process. Use 0 for all devices.
+    .PARAMETER OutputCsvPath
+        Optional CSV export path.
+    .PARAMETER OutputJsonPath
+        Optional JSON export path.
+    .PARAMETER PivotSummary
+        Print a per-app summary after the report is built.
     .EXAMPLE
-        Search-IntuneRawEndpoint -SearchText "iOS - Wi-Fi M-Smartphone"
+        Export-IntuneAppInventory -ApplicationName "TeamViewer"
     .EXAMPLE
-        Search-IntuneRawEndpoint -SearchText "Wi-Fi" -GridView
-    .EXAMPLE
-        Search-IntuneRawEndpoint -SearchText "Wi-Fi" -Endpoint 'beta/deviceManagement/configurationPolicies?$top=100'
+        Export-IntuneAppInventory -ApplicationName "Microsoft*" -IncludeDeployedApps -FilterByType Win32 -OutputCsvPath "apps.csv"
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('Name', 'DisplayName', 'ProfileName', 'Query')]
-        [string]$SearchText,
-        [string[]]$Endpoint,
-        [switch]$Exact,
-        [switch]$GridView
+        [Alias('SearchText', 'Name', 'DisplayName', 'Query', 'AppName')]
+        [string]$ApplicationName,
+
+        [string]$MinimumVersion,
+
+        [ValidateSet('Win32', 'Store', 'LOB', 'Web', 'iOS', 'Android', 'macOS', 'All')]
+        [string]$FilterByType = 'All',
+
+        [ValidateSet('Windows', 'iOS', 'Android', 'macOS', 'All')]
+        [string]$FilterByPlatform = 'All',
+
+        [switch]$OnlySuccessfulInstalls,
+        [switch]$IncludeDeployedApps,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]$MaxDevices = 0,
+
+        [string]$OutputCsvPath,
+        [string]$OutputJsonPath,
+        [switch]$PivotSummary
     )
 
     begin {
         $graphConnected = $null
-
-        function Invoke-NCRawGraphCollectionRequest {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $true)]
-                [string]$Uri
-            )
-
-            $items = [System.Collections.Generic.List[object]]::new()
-            $nextUri = $Uri
-
-            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
-
-                $pageItems = @()
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('value')) {
-                        $value = $response['value']
-                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                            foreach ($entry in $value) {
-                                if ($null -ne $entry) { $pageItems += $entry }
-                            }
-                        }
-                        elseif ($null -ne $value) {
-                            $pageItems = @($value)
-                        }
-                    }
-                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
-                        $pageItems = @($response)
-                    }
-                }
-                elseif ($response -is [System.Array]) {
-                    $pageItems = @($response)
-                }
-                elseif ($response.PSObject.Properties.Name -contains 'value') {
-                    $value = $response.value
-                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                        foreach ($entry in $value) {
-                            if ($null -ne $entry) { $pageItems += $entry }
-                        }
-                    }
-                    elseif ($null -ne $value) {
-                        $pageItems = @($value)
-                    }
-                }
-                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
-                    $pageItems = @($response)
-                }
-
-                foreach ($item in $pageItems) {
-                    $items.Add($item) | Out-Null
-                }
-
-                $nextLink = $null
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('@odata.nextLink')) {
-                        $nextLink = [string]$response['@odata.nextLink']
-                    }
-                }
-                else {
-                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
-                    if ($nextLinkProperty) {
-                        $nextLink = [string]$nextLinkProperty.Value
-                    }
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
-                    $nextUri = $nextLink
-                }
-                else {
-                    $nextUri = $null
-                }
-            }
-
-            return $items.ToArray()
-        }
-
-        function Get-NCRawItemName {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
-                $property = $Item.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    return [string]$property.Value
-                }
-            }
-
-            return $null
-        }
-
-        function Get-NCRawItemId {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            foreach ($propertyName in @('id', 'Id')) {
-                $property = $Item.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    return [string]$property.Value
-                }
-            }
-
-            return $null
-        }
-
-        function Get-NCRawItemODataType {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            if (-not $Item) { return $null }
-
-            $odataProperty = $Item.PSObject.Properties['@odata.type']
-            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
-                return [string]$odataProperty.Value
-            }
-
-            $additionalProperties = $Item.PSObject.Properties['AdditionalProperties']
-            if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
-                return [string]$additionalProperties.Value['@odata.type']
-            }
-
-            return $null
-        }
-
-        function Get-NCRawSearchFields {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $false)]
-                $Item
-            )
-
-            $fields = [System.Collections.Generic.List[object]]::new()
-            if (-not $Item) { return $fields.ToArray() }
-
-            foreach ($propertyName in @('id', 'Id', 'displayName', 'DisplayName', 'name', 'Name', 'description', 'Description', 'networkName', 'NetworkName', 'ssid', 'Ssid')) {
-                $property = $Item.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    $fields.Add([pscustomobject]@{
-                            Property = $propertyName
-                            Value    = [string]$property.Value
-                        }) | Out-Null
-                }
-            }
-
-            return $fields.ToArray()
-        }
     }
 
     process {
-        if ($null -eq $graphConnected) {
-            $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-            if (-not $graphConnected) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        try {
+            if ($null -eq $graphConnected) {
+                $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementManagedDevices.Read.All', 'DeviceManagementApps.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+                if (-not $graphConnected) {
+                    Add-EmptyLine
+                    Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                    return
+                }
+
+                if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                    Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+                    return
+                }
+            }
+
+            if ([string]::IsNullOrWhiteSpace($ApplicationName)) {
+                Write-NCMessage "ApplicationName cannot be empty." -Level WARNING
                 return
             }
 
-            if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
-                Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
-                return
+            Write-Information "Starting app inventory reporting..." -InformationAction Continue
+
+            # 1) Pull devices
+            $devicesUri = "https://graph.microsoft.com/v1.0/deviceManagement/managedDevices"
+            if ($MaxDevices -gt 0) {
+                $devicesUri += "?`$top=$MaxDevices"
             }
-        }
-
-        if ([string]::IsNullOrWhiteSpace($SearchText)) {
-            Write-NCMessage "SearchText cannot be empty." -Level WARNING
-            return
-        }
-
-        $endpointsToProbe = if ($Endpoint -and $Endpoint.Count -gt 0) {
-            @($Endpoint)
-        }
-        else {
-            @(
-                'v1.0/deviceManagement/deviceConfigurations?$top=100',
-                'beta/deviceManagement/deviceConfigurations?$top=100',
-                'v1.0/deviceManagement/configurationPolicies?$top=100',
-                'beta/deviceManagement/configurationPolicies?$top=100',
-                'beta/deviceManagement/groupPolicyConfigurations?$top=100',
-                'beta/deviceManagement/resourceAccessProfiles?$top=100',
-                'v1.0/deviceManagement/deviceCompliancePolicies?$top=100',
-                'v1.0/deviceManagement/deviceEnrollmentConfigurations?$top=100',
-                'beta/deviceManagement/deviceHealthScripts?$top=100',
-                'beta/deviceManagement/deviceManagementScripts?$top=100',
-                'beta/deviceManagement/deviceShellScripts?$top=100',
-                'beta/deviceManagement/intent?$top=100',
-                'beta/deviceManagement/templates?$top=100',
-                'beta/deviceAppManagement/mobileApps?$top=100'
-            )
-        }
-
-        $normalizedSearch = $SearchText.Trim()
-        $results = [System.Collections.Generic.List[object]]::new()
-
-        foreach ($endpointUri in $endpointsToProbe) {
-            $items = @()
-            try {
-                $items = @(Invoke-NCRawGraphCollectionRequest -Uri $endpointUri)
+            $devices = @(Invoke-NCGraphAllPagesCore -Uri $devicesUri)
+            if ($FilterByPlatform -ne "All") {
+                $devices = $devices | Where-Object { $_.operatingSystem -like "$FilterByPlatform*" }
             }
-            catch {
-                Write-NCMessage "Unable to query $endpointUri : $($_.Exception.Message)" -Level WARNING
-                continue
-            }
+            Write-Information "✓ Devices retrieved: $($devices.Count)" -InformationAction Continue
 
-            foreach ($item in $items) {
-                $itemName = Get-NCRawItemName -Item $item
-                $searchFields = @(Get-NCRawSearchFields -Item $item)
-                if ($searchFields.Count -eq 0) {
-                    continue
-                }
-
-                $matchedField = $null
-                foreach ($field in $searchFields) {
-                    $isMatch = if ($Exact.IsPresent) {
-                        $field.Value -eq $normalizedSearch
-                    }
-                    else {
-                        $field.Value -like "*$normalizedSearch*"
-                    }
-
-                    if ($isMatch) {
-                        $matchedField = $field
-                        break
-                    }
-                }
-
-                if (-not $matchedField) {
-                    continue
-                }
-
-                $results.Add([pscustomobject][ordered]@{
-                        'Profile Name'      = $itemName
-                        'Endpoint'          = $endpointUri
-                        'Matched Property'  = $matchedField.Property
-                        'Matched Value'     = $matchedField.Value
-                        'Profile Id'        = Get-NCRawItemId -Item $item
-                        'Profile Type'      = Get-NCRawItemODataType -Item $item
-                    }) | Out-Null
-            }
-        }
-
-        Add-EmptyLine
-        Write-NCMessage "Raw Intune matches found for '$normalizedSearch': $($results.Count)" -Level VERBOSE
-
-        if ($results.Count -eq 0) {
-            Write-NCMessage "No raw Intune matches found for '$normalizedSearch' in the probed endpoints." -Level WARNING
-            return
-        }
-
-        $sorted = $results | Sort-Object 'Profile Name', 'Endpoint' -Unique
-        if ($GridView.IsPresent) {
-            $sorted | Out-GridView -Title "Intune Raw Endpoint Search - $normalizedSearch"
-        }
-        else {
-            $sorted
-        }
-    }
-}
-
-function Search-IntuneObjectById {
-    <#
-    .SYNOPSIS
-        Probes raw Intune Microsoft Graph object endpoints by ID.
-    .DESCRIPTION
-        Connects to Microsoft Graph and attempts direct GET requests against a curated set of
-        Intune deviceManagement object endpoints using the provided ID. Use this when an object
-        does not appear in collection listings but you have an identifier from the Intune portal.
-    .PARAMETER Id
-        Object ID to probe across Intune Graph endpoints.
-    .PARAMETER Endpoint
-        Optional custom object endpoint prefixes. When omitted, a built-in curated list is used.
-    .PARAMETER GridView
-        Show the results in Out-GridView instead of returning objects.
-    .EXAMPLE
-        Search-IntuneObjectById -Id "cbbf1b23-3a92-47d6-974b-9d8295b9978d"
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('ObjectId', 'ProfileId')]
-        [string]$Id,
-        [string[]]$Endpoint,
-        [switch]$GridView
-    )
-
-    process {
-        $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-        if (-not $graphConnected) {
-            Add-EmptyLine
-            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-            return
-        }
-
-        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
-            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
-            return
-        }
-
-        if ([string]::IsNullOrWhiteSpace($Id)) {
-            Write-NCMessage "Id cannot be empty." -Level WARNING
-            return
-        }
-
-        $endpointPrefixes = if ($Endpoint -and $Endpoint.Count -gt 0) {
-            @($Endpoint)
-        }
-        else {
-            @(
-                'v1.0/deviceManagement/deviceConfigurations',
-                'beta/deviceManagement/deviceConfigurations',
-                'v1.0/deviceManagement/configurationPolicies',
-                'beta/deviceManagement/configurationPolicies',
-                'beta/deviceManagement/groupPolicyConfigurations',
-                'beta/deviceManagement/resourceAccessProfiles',
-                'v1.0/deviceManagement/deviceCompliancePolicies',
-                'v1.0/deviceManagement/deviceEnrollmentConfigurations',
-                'beta/deviceManagement/deviceHealthScripts',
-                'beta/deviceManagement/deviceManagementScripts',
-                'beta/deviceManagement/deviceShellScripts',
-                'beta/deviceManagement/intents',
-                'beta/deviceManagement/templates',
-                'beta/deviceAppManagement/mobileApps'
-            )
-        }
-
-        $results = [System.Collections.Generic.List[object]]::new()
-        foreach ($prefix in $endpointPrefixes) {
-            $uri = "$prefix/$Id"
-            try {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $uri -ErrorAction Stop
-            }
-            catch {
-                continue
-            }
-
-            $name = $null
-            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
-                $property = $response.PSObject.Properties[$propertyName]
-                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
-                    $name = [string]$property.Value
-                    break
-                }
-            }
-
-            $odataType = $null
-            $odataProperty = $response.PSObject.Properties['@odata.type']
-            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
-                $odataType = [string]$odataProperty.Value
-            }
-            else {
-                $additionalProperties = $response.PSObject.Properties['AdditionalProperties']
-                if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
-                    $odataType = [string]$additionalProperties.Value['@odata.type']
-                }
-            }
-
-            $results.Add([pscustomobject][ordered]@{
-                    'Endpoint'     = $prefix
-                    'Profile Id'   = $Id
-                    'Profile Name' = $name
-                    'Profile Type' = $odataType
-                }) | Out-Null
-        }
-
-        Add-EmptyLine
-        Write-NCMessage "Direct Intune endpoint matches found for '$Id': $($results.Count)" -Level VERBOSE
-
-        if ($results.Count -eq 0) {
-            Write-NCMessage "No direct Intune endpoint matches found for '$Id' in the probed endpoints." -Level WARNING
-            return
-        }
-
-        $sorted = $results | Sort-Object 'Endpoint' -Unique
-        if ($GridView.IsPresent) {
-            $sorted | Out-GridView -Title "Intune Direct Object Search - $Id"
-        }
-        else {
-            $sorted
-        }
-    }
-}
-
-function Get-IntuneProfileAssignmentsRaw {
-    <#
-    .SYNOPSIS
-        Returns raw Intune profile assignments for a specific profile ID.
-    .DESCRIPTION
-        Probes multiple Microsoft Graph assignment endpoints for the provided profile ID and returns
-        the raw assignment target details. Use this to understand how Intune exposes assignment data
-        for profiles that do not behave as expected through higher-level helper functions.
-    .PARAMETER ProfileId
-        Intune profile ID to inspect.
-    .PARAMETER GridView
-        Show the results in Out-GridView instead of returning objects.
-    .EXAMPLE
-        Get-IntuneProfileAssignmentsRaw -ProfileId "00000000-0000-0000-0000-000000000000"
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('Id', 'ObjectId')]
-        [string]$ProfileId,
-        [switch]$GridView
-    )
-
-    begin {
-        function Invoke-NCRawAssignmentCollectionRequest {
-            [CmdletBinding()]
-            param(
-                [Parameter(Mandatory = $true)]
-                [string]$Uri
-            )
-
-            $items = [System.Collections.Generic.List[object]]::new()
-            $nextUri = $Uri
-
-            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
-                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
-
-                $pageItems = @()
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('value')) {
-                        $value = $response['value']
-                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                            foreach ($entry in $value) {
-                                if ($null -ne $entry) { $pageItems += $entry }
+            # 2) Build app->device mapping from Detected Apps
+            $appDeviceMap = @{}
+            $processed = 0
+            foreach ($device in $devices) {
+                $processed++
+                Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
+                try {
+                    $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
+                    $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET -ErrorAction Stop
+                    foreach ($app in ($deviceWithApps.detectedApps | Where-Object { $_.displayName -like $ApplicationName })) {
+                        if ($MinimumVersion -and $app.version) {
+                            if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
+                                continue
                             }
                         }
-                        elseif ($null -ne $value) {
-                            $pageItems = @($value)
+                        $key = $app.displayName
+                        if (-not $appDeviceMap.ContainsKey($key)) {
+                            $appDeviceMap[$key] = [ordered]@{ Devices = @(); Versions = @{}; Publishers = @{} }
+                        }
+                        $appDeviceMap[$key].Devices += [ordered]@{
+                            DeviceId   = $device.id
+                            DeviceName = $device.deviceName
+                            Platform   = $device.operatingSystem
+                            User       = $device.userPrincipalName
+                            Version    = $app.version
+                            Publisher  = $app.publisher
+                            Source     = "DetectedApps"
+                        }
+                        if ($app.version)   { $appDeviceMap[$key].Versions[$app.version]   = ($appDeviceMap[$key].Versions[$app.version]   + 1) }
+                        if ($app.publisher) { $appDeviceMap[$key].Publishers[$app.publisher] = ($appDeviceMap[$key].Publishers[$app.publisher] + 1) }
+                    }
+                    Start-Sleep -Milliseconds 40
+                }
+                catch {
+                    if ($_.Exception.Message -like "*429*") {
+                        Write-Information "`nRate limit hit, waiting 60 seconds..." -InformationAction Continue
+                        Start-Sleep -Seconds 60
+                        $processed--
+                        continue
+                    }
+                    Write-Warning "Error reading apps for $($device.deviceName): $($_.Exception.Message)"
+                }
+            }
+            Write-Progress -Activity "Reading Detected Apps" -Completed
+
+            # 3) Optionally incorporate deployment statuses (broadens coverage)
+            if ($IncludeDeployedApps) {
+                Write-Information "Including deployed apps device status..." -InformationAction Continue
+                $appsUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
+                $allApps = @(Invoke-NCGraphAllPagesCore -Uri $appsUri)
+                foreach ($app in $allApps | Where-Object { $_.displayName -like $ApplicationName }) {
+                    $appType = Get-NCIntuneAppTypeFromODataType -ODataType $app.'@odata.type'
+                    if ($FilterByType -ne "All" -and $appType -ne $FilterByType) {
+                        continue
+                    }
+                    $statusUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/deviceStatuses"
+                    $statuses = @(Invoke-NCGraphAllPagesCore -Uri $statusUri)
+                    foreach ($s in $statuses) {
+                        if ($OnlySuccessfulInstalls -and $s.installState -ne "installed") {
+                            continue
+                        }
+                        $d = $devices | Where-Object { $_.id -eq $s.deviceId } | Select-Object -First 1
+                        if (-not $d) {
+                            continue
+                        }
+                        $key = $app.displayName
+                        if (-not $appDeviceMap.ContainsKey($key)) {
+                            $appDeviceMap[$key] = [ordered]@{ Devices = @(); Versions = @{}; Publishers = @{} }
+                        }
+                        # Avoid duplicates for the same device/app when DetectedApps already included it
+                        $exists = $appDeviceMap[$key].Devices | Where-Object { $_.DeviceId -eq $d.id }
+                        if (-not $exists) {
+                            $appDeviceMap[$key].Devices += [ordered]@{
+                                DeviceId     = $d.id
+                                DeviceName   = $d.deviceName
+                                Platform     = $d.operatingSystem
+                                User         = $d.userPrincipalName
+                                Version      = $null
+                                Publisher    = $null
+                                InstallState = $s.installState
+                                AppType      = $appType
+                                Source       = "DeploymentStatus"
+                            }
                         }
                     }
-                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
-                        $pageItems = @($response)
-                    }
-                }
-                elseif ($response -is [System.Array]) {
-                    $pageItems = @($response)
-                }
-                elseif ($response.PSObject.Properties.Name -contains 'value') {
-                    $value = $response.value
-                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
-                        foreach ($entry in $value) {
-                            if ($null -ne $entry) { $pageItems += $entry }
-                        }
-                    }
-                    elseif ($null -ne $value) {
-                        $pageItems = @($value)
-                    }
-                }
-                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
-                    $pageItems = @($response)
-                }
-
-                foreach ($item in $pageItems) {
-                    $items.Add($item) | Out-Null
-                }
-
-                $nextLink = $null
-                if ($response -is [System.Collections.IDictionary]) {
-                    if ($response.Contains('@odata.nextLink')) {
-                        $nextLink = [string]$response['@odata.nextLink']
-                    }
-                }
-                else {
-                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
-                    if ($nextLinkProperty) {
-                        $nextLink = [string]$nextLinkProperty.Value
-                    }
-                }
-
-                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
-                    $nextUri = $nextLink
-                }
-                else {
-                    $nextUri = $null
                 }
             }
 
-            return $items.ToArray()
-        }
-    }
-
-    process {
-        $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-        if (-not $graphConnected) {
-            Add-EmptyLine
-            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-            return
-        }
-
-        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
-            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
-            return
-        }
-
-        $assignmentEndpoints = @(
-            "beta/deviceManagement/deviceConfigurations('$ProfileId')/assignments?`$top=100",
-            "v1.0/deviceManagement/deviceConfigurations('$ProfileId')/assignments?`$top=100",
-            "beta/deviceManagement/configurationPolicies('$ProfileId')/assignments?`$top=100",
-            "beta/deviceManagement/groupPolicyConfigurations('$ProfileId')/assignments?`$top=100",
-            "beta/deviceManagement/resourceAccessProfiles('$ProfileId')/assignments?`$top=100"
-        )
-
-        $results = [System.Collections.Generic.List[object]]::new()
-        foreach ($endpoint in $assignmentEndpoints) {
-            $assignments = @()
-            try {
-                $assignments = @(Invoke-NCRawAssignmentCollectionRequest -Uri $endpoint)
-            }
-            catch {
-                continue
+            # 4) Optional app type filter when only Detected Apps were used
+            if (-not $IncludeDeployedApps -and $FilterByType -ne "All") {
+                Write-Verbose "FilterByType applies only when -IncludeDeployedApps is used. Skipping type filter for Detected Apps only."
             }
 
-            foreach ($assignment in $assignments) {
-                $target = $null
-                if ($assignment -is [System.Collections.IDictionary]) {
-                    foreach ($key in @('target', 'Target')) {
-                        if ($assignment.Contains($key) -and $null -ne $assignment[$key]) {
-                            $target = $assignment[$key]
-                            break
-                        }
+            # 5) Build flat rows
+            $rows = @()
+            foreach ($appName in $appDeviceMap.Keys) {
+                foreach ($dev in $appDeviceMap[$appName].Devices) {
+                    $rows += [pscustomobject]@{
+                        AppName      = $appName
+                        Version      = $dev.Version
+                        Publisher    = $dev.Publisher
+                        AppType      = $dev.AppType
+                        DeviceName   = $dev.DeviceName
+                        DeviceId     = $dev.DeviceId
+                        Platform     = $dev.Platform
+                        User         = $dev.User
+                        InstallState = $dev.InstallState
+                        Source       = $dev.Source
                     }
                 }
-                elseif ($assignment.PSObject.Properties['Target']) {
-                    $target = $assignment.Target
-                }
-                elseif ($assignment.PSObject.Properties['target']) {
-                    $target = $assignment.PSObject.Properties['target'].Value
-                }
-
-                $targetProps = @{}
-                if ($target) {
-                    foreach ($prop in $target.PSObject.Properties) {
-                        if ($prop.Name -ne 'AdditionalProperties') {
-                            $targetProps[$prop.Name] = $prop.Value
-                        }
-                    }
-
-                    $additionalTargetProperties = $target.PSObject.Properties['AdditionalProperties']
-                    if ($additionalTargetProperties -and $additionalTargetProperties.Value) {
-                        foreach ($key in $additionalTargetProperties.Value.Keys) {
-                            $targetProps[$key] = $additionalTargetProperties.Value[$key]
-                        }
-                    }
-                }
-
-                $assignmentId = $null
-                if ($assignment -is [System.Collections.IDictionary]) {
-                    foreach ($key in @('id', 'Id')) {
-                        if ($assignment.Contains($key) -and -not [string]::IsNullOrWhiteSpace([string]$assignment[$key])) {
-                            $assignmentId = [string]$assignment[$key]
-                            break
-                        }
-                    }
-                }
-                elseif ($assignment.PSObject.Properties['Id']) {
-                    $assignmentId = $assignment.Id
-                }
-                elseif ($assignment.PSObject.Properties['id']) {
-                    $assignmentId = $assignment.PSObject.Properties['id'].Value
-                }
-
-                $results.Add([pscustomobject][ordered]@{
-                        'Endpoint'         = $endpoint
-                        'Assignment Id'    = $assignmentId
-                        'Target Summary'   = ($targetProps.GetEnumerator() | Sort-Object Name | ForEach-Object { "{0}={1}" -f $_.Name, $_.Value }) -join '; '
-                        'Target Properties' = [pscustomobject]$targetProps
-                    }) | Out-Null
             }
-        }
 
-        Add-EmptyLine
-        Write-NCMessage "Raw assignment rows found for '$ProfileId': $($results.Count)" -Level VERBOSE
+            if (-not $rows -or $rows.Count -eq 0) {
+                Write-Warning "No matches found for '$ApplicationName' with the provided filters."
+                return
+            }
 
-        if ($results.Count -eq 0) {
-            Write-NCMessage "No raw assignments found for '$ProfileId' in the probed endpoints." -Level WARNING
-            return
-        }
+            # 6) Console table output
+            $rows | Sort-Object AppName, DeviceName | Format-Table -AutoSize AppName, Version, Publisher, AppType, DeviceName, Platform, User, InstallState, Source
 
-        $sorted = $results | Sort-Object 'Endpoint', 'Assignment Id' -Unique
-        if ($GridView.IsPresent) {
-            $sorted | Out-GridView -Title "Intune Raw Assignments - $ProfileId"
+            # 7) Optional exports
+            if ($OutputCsvPath) {
+                try {
+                    $rows | Sort-Object AppName, DeviceName | Export-Csv -Path $OutputCsvPath -NoTypeInformation -Encoding UTF8
+                    Write-Information "✓ CSV exported to $OutputCsvPath" -InformationAction Continue
+                }
+                catch {
+                    Write-Warning "Failed to export CSV: $($_.Exception.Message)"
+                }
+            }
+
+            if ($OutputJsonPath) {
+                try {
+                    $rows | ConvertTo-Json -Depth 5 | Out-File -FilePath $OutputJsonPath -Encoding UTF8
+                    Write-Information "✓ JSON exported to $OutputJsonPath" -InformationAction Continue
+                }
+                catch {
+                    Write-Warning "Failed to export JSON: $($_.Exception.Message)"
+                }
+            }
+
+            # 8) Optional per-app pivot/summary
+            if ($PivotSummary) {
+                Write-Host "`n=== SUMMARY BY APPLICATION ===" -ForegroundColor Cyan
+                $rows | Group-Object AppName | Sort-Object Count -Descending | ForEach-Object {
+                    $app = $_.Name
+                    $count = $_.Count
+                    $versions = ($_.Group | Where-Object Version | Group-Object Version | Sort-Object Count -Descending | ForEach-Object { "{0} ({1})" -f $_.Name, $_.Count }) -join ", "
+                    $publishers = ($_.Group | Where-Object Publisher | Group-Object Publisher | Sort-Object Count -Descending | Select-Object -First 3 | ForEach-Object { "{0} ({1})" -f $_.Name, $_.Count }) -join ", "
+                    "• {0}: {1} devices`n    Versions: {2}`n    Top publishers: {3}" -f $app, $count, ($(if ($versions) { $versions } else { 'n/a' })), ($(if ($publishers) { $publishers } else { 'n/a' }))
+                }
+            }
+
+            Write-Information "`n🎉 Reporting completed successfully!" -InformationAction Continue
         }
-        else {
-            $sorted
+        catch {
+            Write-Error "Script execution failed: $($_.Exception.Message)"
+            exit 1
         }
     }
 }

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -1,0 +1,935 @@
+#Requires -Version 5.0
+using namespace System.Management.Automation
+
+# Nebula.Core: Intune ===============================================================================================================================
+
+function Get-IntuneProfileAssignmentsByGroup {
+    [CmdletBinding(DefaultParameterSetName = 'ByName')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Group', 'DisplayName', 'Name', 'Identity')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [string]$GroupId,
+
+        [string]$ProfileName,
+        [string]$ProfileId,
+        [switch]$IncludeNestedGroups,
+        [switch]$GridView,
+        [switch]$Diagnostic
+    )
+
+    process {
+        Invoke-NCIntuneGroupUsageCore -ParameterSetName $PSCmdlet.ParameterSetName -GroupName $GroupName -GroupId $GroupId -ProfileName $ProfileName -ProfileId $ProfileId -IncludeNestedGroups:$IncludeNestedGroups -GridView:$GridView -Diagnostic:$Diagnostic
+    }
+}
+
+function Search-IntuneProfileLocation {
+    <#
+    .SYNOPSIS
+        Finds where an Intune profile lives across multiple Microsoft Graph surfaces.
+    .DESCRIPTION
+        Connects to Microsoft Graph and searches a curated set of Intune endpoints for profile names
+        matching the provided text. Use this command to identify the correct source before querying
+        assignments or extending support for new profile families.
+    .PARAMETER SearchText
+        Profile name text to search for.
+    .PARAMETER Exact
+        Match the profile name exactly instead of using a contains search.
+    .PARAMETER GridView
+        Show the results in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Search-IntuneProfileLocation -SearchText "iOS - Wi-Fi M-Smartphone"
+    .EXAMPLE
+        Search-IntuneProfileLocation -SearchText "Wi-Fi" -GridView
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Name', 'DisplayName', 'ProfileName', 'Query')]
+        [string]$SearchText,
+        [switch]$Exact,
+        [switch]$GridView
+    )
+
+    begin {
+        $graphConnected = $null
+
+        function Invoke-NCGraphCollectionRequestLocal {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$Uri
+            )
+
+            $items = [System.Collections.Generic.List[object]]::new()
+            $nextUri = $Uri
+
+            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
+
+                $pageItems = @()
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('value')) {
+                        $value = $response['value']
+                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                            foreach ($entry in $value) {
+                                if ($null -ne $entry) { $pageItems += $entry }
+                            }
+                        }
+                        elseif ($null -ne $value) {
+                            $pageItems = @($value)
+                        }
+                    }
+                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
+                        $pageItems = @($response)
+                    }
+                }
+                elseif ($response -is [System.Array]) {
+                    $pageItems = @($response)
+                }
+                elseif ($response.PSObject.Properties.Name -contains 'value') {
+                    $value = $response.value
+                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                        foreach ($entry in $value) {
+                            if ($null -ne $entry) { $pageItems += $entry }
+                        }
+                    }
+                    elseif ($null -ne $value) {
+                        $pageItems = @($value)
+                    }
+                }
+                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
+                    $pageItems = @($response)
+                }
+
+                foreach ($item in $pageItems) {
+                    $items.Add($item) | Out-Null
+                }
+
+                $nextLink = $null
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('@odata.nextLink')) {
+                        $nextLink = [string]$response['@odata.nextLink']
+                    }
+                }
+                else {
+                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
+                    if ($nextLinkProperty) {
+                        $nextLink = [string]$nextLinkProperty.Value
+                    }
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
+                    $nextUri = $nextLink
+                }
+                else {
+                    $nextUri = $null
+                }
+            }
+
+            return $items.ToArray()
+        }
+
+        function Get-NCIntuneItemName {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
+                $property = $Item.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    return [string]$property.Value
+                }
+            }
+
+            return $null
+        }
+
+        function Get-NCIntuneItemId {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            foreach ($propertyName in @('id', 'Id')) {
+                $property = $Item.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    return [string]$property.Value
+                }
+            }
+
+            return $null
+        }
+
+        function Get-NCIntuneItemODataType {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            $odataProperty = $Item.PSObject.Properties['@odata.type']
+            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
+                return [string]$odataProperty.Value
+            }
+
+            $additionalProperties = $Item.PSObject.Properties['AdditionalProperties']
+            if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
+                return [string]$additionalProperties.Value['@odata.type']
+            }
+
+            return $null
+        }
+    }
+
+    process {
+        if ($null -eq $graphConnected) {
+            $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+            if (-not $graphConnected) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+                return
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($SearchText)) {
+            Write-NCMessage "SearchText cannot be empty." -Level WARNING
+            return
+        }
+
+        $endpoints = @(
+            @{ Source = 'deviceConfigurations'; Uris = @('v1.0/deviceManagement/deviceConfigurations?$top=100') },
+            @{ Source = 'betaDeviceConfigurations'; Uris = @('beta/deviceManagement/deviceConfigurations?$top=100') },
+            @{ Source = 'configurationPolicies'; Uris = @('v1.0/deviceManagement/configurationPolicies?$top=100', 'beta/deviceManagement/configurationPolicies?$top=100') },
+            @{ Source = 'groupPolicyConfigurations'; Uris = @('beta/deviceManagement/groupPolicyConfigurations?$top=100') },
+            @{ Source = 'resourceAccessProfiles'; Uris = @('beta/deviceManagement/resourceAccessProfiles?$top=100') },
+            @{ Source = 'deviceCompliancePolicies'; Uris = @('v1.0/deviceManagement/deviceCompliancePolicies?$top=100') },
+            @{ Source = 'deviceEnrollmentConfigurations'; Uris = @('v1.0/deviceManagement/deviceEnrollmentConfigurations?$top=100') },
+            @{ Source = 'deviceHealthScripts'; Uris = @('beta/deviceManagement/deviceHealthScripts?$top=100') },
+            @{ Source = 'deviceManagementScripts'; Uris = @('beta/deviceManagement/deviceManagementScripts?$top=100') },
+            @{ Source = 'deviceShellScripts'; Uris = @('beta/deviceManagement/deviceShellScripts?$top=100') }
+        )
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        $normalizedSearch = $SearchText.Trim()
+
+        foreach ($endpoint in $endpoints) {
+            $items = @()
+            $queried = $false
+            $lastError = $null
+
+            foreach ($endpointUri in $endpoint.Uris) {
+                try {
+                    $items = @(Invoke-NCGraphCollectionRequestLocal -Uri $endpointUri)
+                    $queried = $true
+                    break
+                }
+                catch {
+                    $lastError = $_.Exception.Message
+                }
+            }
+
+            if (-not $queried) {
+                if ($lastError) {
+                    Write-NCMessage "Unable to query $($endpoint.Source): $lastError" -Level WARNING
+                }
+                continue
+            }
+
+            foreach ($item in $items) {
+                $itemName = Get-NCIntuneItemName -Item $item
+                if ([string]::IsNullOrWhiteSpace($itemName)) {
+                    continue
+                }
+
+                $isMatch = if ($Exact.IsPresent) {
+                    $itemName -eq $normalizedSearch
+                }
+                else {
+                    $itemName -like "*$normalizedSearch*"
+                }
+
+                if (-not $isMatch) {
+                    continue
+                }
+
+                $results.Add([pscustomobject][ordered]@{
+                        'Profile Name' = $itemName
+                        'Source'       = $endpoint.Source
+                        'Profile Id'   = Get-NCIntuneItemId -Item $item
+                        'Profile Type' = Get-NCIntuneItemODataType -Item $item
+                    }) | Out-Null
+            }
+        }
+
+        Add-EmptyLine
+        Write-NCMessage "Intune profiles found for '$normalizedSearch': $($results.Count)" -Level VERBOSE
+
+        if ($results.Count -eq 0) {
+            Write-NCMessage "No Intune profiles found for '$normalizedSearch' in the currently scanned endpoints." -Level WARNING
+            return
+        }
+
+        $sorted = $results | Sort-Object 'Profile Name', 'Source' -Unique
+        if ($GridView.IsPresent) {
+            $sorted | Out-GridView -Title "Intune Profile Search - $normalizedSearch"
+        }
+        else {
+            $sorted
+        }
+    }
+}
+
+function Search-IntuneRawEndpoint {
+    <#
+    .SYNOPSIS
+        Probes raw Intune Microsoft Graph endpoints and filters results by profile name.
+    .DESCRIPTION
+        Connects to Microsoft Graph, queries a curated set of Intune deviceManagement endpoints,
+        and returns any items whose common identifying properties or object ID match the provided search text.
+        Use this as a low-level discovery tool when a profile is not found by the higher-level
+        Intune helper functions.
+    .PARAMETER SearchText
+        Text to search for in the returned profile names.
+    .PARAMETER Endpoint
+        Optional custom endpoint URIs to probe. When omitted, a built-in curated list is used.
+    .PARAMETER Exact
+        Match the profile name exactly instead of using a contains search.
+    .PARAMETER GridView
+        Show the results in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Search-IntuneRawEndpoint -SearchText "iOS - Wi-Fi M-Smartphone"
+    .EXAMPLE
+        Search-IntuneRawEndpoint -SearchText "Wi-Fi" -GridView
+    .EXAMPLE
+        Search-IntuneRawEndpoint -SearchText "Wi-Fi" -Endpoint 'beta/deviceManagement/configurationPolicies?$top=100'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Name', 'DisplayName', 'ProfileName', 'Query')]
+        [string]$SearchText,
+        [string[]]$Endpoint,
+        [switch]$Exact,
+        [switch]$GridView
+    )
+
+    begin {
+        $graphConnected = $null
+
+        function Invoke-NCRawGraphCollectionRequest {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$Uri
+            )
+
+            $items = [System.Collections.Generic.List[object]]::new()
+            $nextUri = $Uri
+
+            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
+
+                $pageItems = @()
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('value')) {
+                        $value = $response['value']
+                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                            foreach ($entry in $value) {
+                                if ($null -ne $entry) { $pageItems += $entry }
+                            }
+                        }
+                        elseif ($null -ne $value) {
+                            $pageItems = @($value)
+                        }
+                    }
+                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
+                        $pageItems = @($response)
+                    }
+                }
+                elseif ($response -is [System.Array]) {
+                    $pageItems = @($response)
+                }
+                elseif ($response.PSObject.Properties.Name -contains 'value') {
+                    $value = $response.value
+                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                        foreach ($entry in $value) {
+                            if ($null -ne $entry) { $pageItems += $entry }
+                        }
+                    }
+                    elseif ($null -ne $value) {
+                        $pageItems = @($value)
+                    }
+                }
+                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
+                    $pageItems = @($response)
+                }
+
+                foreach ($item in $pageItems) {
+                    $items.Add($item) | Out-Null
+                }
+
+                $nextLink = $null
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('@odata.nextLink')) {
+                        $nextLink = [string]$response['@odata.nextLink']
+                    }
+                }
+                else {
+                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
+                    if ($nextLinkProperty) {
+                        $nextLink = [string]$nextLinkProperty.Value
+                    }
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
+                    $nextUri = $nextLink
+                }
+                else {
+                    $nextUri = $null
+                }
+            }
+
+            return $items.ToArray()
+        }
+
+        function Get-NCRawItemName {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
+                $property = $Item.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    return [string]$property.Value
+                }
+            }
+
+            return $null
+        }
+
+        function Get-NCRawItemId {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            foreach ($propertyName in @('id', 'Id')) {
+                $property = $Item.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    return [string]$property.Value
+                }
+            }
+
+            return $null
+        }
+
+        function Get-NCRawItemODataType {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            if (-not $Item) { return $null }
+
+            $odataProperty = $Item.PSObject.Properties['@odata.type']
+            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
+                return [string]$odataProperty.Value
+            }
+
+            $additionalProperties = $Item.PSObject.Properties['AdditionalProperties']
+            if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
+                return [string]$additionalProperties.Value['@odata.type']
+            }
+
+            return $null
+        }
+
+        function Get-NCRawSearchFields {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $false)]
+                $Item
+            )
+
+            $fields = [System.Collections.Generic.List[object]]::new()
+            if (-not $Item) { return $fields.ToArray() }
+
+            foreach ($propertyName in @('id', 'Id', 'displayName', 'DisplayName', 'name', 'Name', 'description', 'Description', 'networkName', 'NetworkName', 'ssid', 'Ssid')) {
+                $property = $Item.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    $fields.Add([pscustomobject]@{
+                            Property = $propertyName
+                            Value    = [string]$property.Value
+                        }) | Out-Null
+                }
+            }
+
+            return $fields.ToArray()
+        }
+    }
+
+    process {
+        if ($null -eq $graphConnected) {
+            $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+            if (-not $graphConnected) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+                Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+                return
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($SearchText)) {
+            Write-NCMessage "SearchText cannot be empty." -Level WARNING
+            return
+        }
+
+        $endpointsToProbe = if ($Endpoint -and $Endpoint.Count -gt 0) {
+            @($Endpoint)
+        }
+        else {
+            @(
+                'v1.0/deviceManagement/deviceConfigurations?$top=100',
+                'beta/deviceManagement/deviceConfigurations?$top=100',
+                'v1.0/deviceManagement/configurationPolicies?$top=100',
+                'beta/deviceManagement/configurationPolicies?$top=100',
+                'beta/deviceManagement/groupPolicyConfigurations?$top=100',
+                'beta/deviceManagement/resourceAccessProfiles?$top=100',
+                'v1.0/deviceManagement/deviceCompliancePolicies?$top=100',
+                'v1.0/deviceManagement/deviceEnrollmentConfigurations?$top=100',
+                'beta/deviceManagement/deviceHealthScripts?$top=100',
+                'beta/deviceManagement/deviceManagementScripts?$top=100',
+                'beta/deviceManagement/deviceShellScripts?$top=100',
+                'beta/deviceManagement/intent?$top=100',
+                'beta/deviceManagement/templates?$top=100',
+                'beta/deviceAppManagement/mobileApps?$top=100'
+            )
+        }
+
+        $normalizedSearch = $SearchText.Trim()
+        $results = [System.Collections.Generic.List[object]]::new()
+
+        foreach ($endpointUri in $endpointsToProbe) {
+            $items = @()
+            try {
+                $items = @(Invoke-NCRawGraphCollectionRequest -Uri $endpointUri)
+            }
+            catch {
+                Write-NCMessage "Unable to query $endpointUri : $($_.Exception.Message)" -Level WARNING
+                continue
+            }
+
+            foreach ($item in $items) {
+                $itemName = Get-NCRawItemName -Item $item
+                $searchFields = @(Get-NCRawSearchFields -Item $item)
+                if ($searchFields.Count -eq 0) {
+                    continue
+                }
+
+                $matchedField = $null
+                foreach ($field in $searchFields) {
+                    $isMatch = if ($Exact.IsPresent) {
+                        $field.Value -eq $normalizedSearch
+                    }
+                    else {
+                        $field.Value -like "*$normalizedSearch*"
+                    }
+
+                    if ($isMatch) {
+                        $matchedField = $field
+                        break
+                    }
+                }
+
+                if (-not $matchedField) {
+                    continue
+                }
+
+                $results.Add([pscustomobject][ordered]@{
+                        'Profile Name'      = $itemName
+                        'Endpoint'          = $endpointUri
+                        'Matched Property'  = $matchedField.Property
+                        'Matched Value'     = $matchedField.Value
+                        'Profile Id'        = Get-NCRawItemId -Item $item
+                        'Profile Type'      = Get-NCRawItemODataType -Item $item
+                    }) | Out-Null
+            }
+        }
+
+        Add-EmptyLine
+        Write-NCMessage "Raw Intune matches found for '$normalizedSearch': $($results.Count)" -Level VERBOSE
+
+        if ($results.Count -eq 0) {
+            Write-NCMessage "No raw Intune matches found for '$normalizedSearch' in the probed endpoints." -Level WARNING
+            return
+        }
+
+        $sorted = $results | Sort-Object 'Profile Name', 'Endpoint' -Unique
+        if ($GridView.IsPresent) {
+            $sorted | Out-GridView -Title "Intune Raw Endpoint Search - $normalizedSearch"
+        }
+        else {
+            $sorted
+        }
+    }
+}
+
+function Search-IntuneObjectById {
+    <#
+    .SYNOPSIS
+        Probes raw Intune Microsoft Graph object endpoints by ID.
+    .DESCRIPTION
+        Connects to Microsoft Graph and attempts direct GET requests against a curated set of
+        Intune deviceManagement object endpoints using the provided ID. Use this when an object
+        does not appear in collection listings but you have an identifier from the Intune portal.
+    .PARAMETER Id
+        Object ID to probe across Intune Graph endpoints.
+    .PARAMETER Endpoint
+        Optional custom object endpoint prefixes. When omitted, a built-in curated list is used.
+    .PARAMETER GridView
+        Show the results in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Search-IntuneObjectById -Id "cbbf1b23-3a92-47d6-974b-9d8295b9978d"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('ObjectId', 'ProfileId')]
+        [string]$Id,
+        [string[]]$Endpoint,
+        [switch]$GridView
+    )
+
+    process {
+        $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'DeviceManagementApps.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+        if (-not $graphConnected) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+            return
+        }
+
+        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+            return
+        }
+
+        if ([string]::IsNullOrWhiteSpace($Id)) {
+            Write-NCMessage "Id cannot be empty." -Level WARNING
+            return
+        }
+
+        $endpointPrefixes = if ($Endpoint -and $Endpoint.Count -gt 0) {
+            @($Endpoint)
+        }
+        else {
+            @(
+                'v1.0/deviceManagement/deviceConfigurations',
+                'beta/deviceManagement/deviceConfigurations',
+                'v1.0/deviceManagement/configurationPolicies',
+                'beta/deviceManagement/configurationPolicies',
+                'beta/deviceManagement/groupPolicyConfigurations',
+                'beta/deviceManagement/resourceAccessProfiles',
+                'v1.0/deviceManagement/deviceCompliancePolicies',
+                'v1.0/deviceManagement/deviceEnrollmentConfigurations',
+                'beta/deviceManagement/deviceHealthScripts',
+                'beta/deviceManagement/deviceManagementScripts',
+                'beta/deviceManagement/deviceShellScripts',
+                'beta/deviceManagement/intents',
+                'beta/deviceManagement/templates',
+                'beta/deviceAppManagement/mobileApps'
+            )
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        foreach ($prefix in $endpointPrefixes) {
+            $uri = "$prefix/$Id"
+            try {
+                $response = Invoke-MgGraphRequest -Method GET -Uri $uri -ErrorAction Stop
+            }
+            catch {
+                continue
+            }
+
+            $name = $null
+            foreach ($propertyName in @('displayName', 'DisplayName', 'name', 'Name')) {
+                $property = $response.PSObject.Properties[$propertyName]
+                if ($property -and -not [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+                    $name = [string]$property.Value
+                    break
+                }
+            }
+
+            $odataType = $null
+            $odataProperty = $response.PSObject.Properties['@odata.type']
+            if ($odataProperty -and -not [string]::IsNullOrWhiteSpace([string]$odataProperty.Value)) {
+                $odataType = [string]$odataProperty.Value
+            }
+            else {
+                $additionalProperties = $response.PSObject.Properties['AdditionalProperties']
+                if ($additionalProperties -and $additionalProperties.Value -and $additionalProperties.Value.ContainsKey('@odata.type')) {
+                    $odataType = [string]$additionalProperties.Value['@odata.type']
+                }
+            }
+
+            $results.Add([pscustomobject][ordered]@{
+                    'Endpoint'     = $prefix
+                    'Profile Id'   = $Id
+                    'Profile Name' = $name
+                    'Profile Type' = $odataType
+                }) | Out-Null
+        }
+
+        Add-EmptyLine
+        Write-NCMessage "Direct Intune endpoint matches found for '$Id': $($results.Count)" -Level VERBOSE
+
+        if ($results.Count -eq 0) {
+            Write-NCMessage "No direct Intune endpoint matches found for '$Id' in the probed endpoints." -Level WARNING
+            return
+        }
+
+        $sorted = $results | Sort-Object 'Endpoint' -Unique
+        if ($GridView.IsPresent) {
+            $sorted | Out-GridView -Title "Intune Direct Object Search - $Id"
+        }
+        else {
+            $sorted
+        }
+    }
+}
+
+function Get-IntuneProfileAssignmentsRaw {
+    <#
+    .SYNOPSIS
+        Returns raw Intune profile assignments for a specific profile ID.
+    .DESCRIPTION
+        Probes multiple Microsoft Graph assignment endpoints for the provided profile ID and returns
+        the raw assignment target details. Use this to understand how Intune exposes assignment data
+        for profiles that do not behave as expected through higher-level helper functions.
+    .PARAMETER ProfileId
+        Intune profile ID to inspect.
+    .PARAMETER GridView
+        Show the results in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Get-IntuneProfileAssignmentsRaw -ProfileId "00000000-0000-0000-0000-000000000000"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Id', 'ObjectId')]
+        [string]$ProfileId,
+        [switch]$GridView
+    )
+
+    begin {
+        function Invoke-NCRawAssignmentCollectionRequest {
+            [CmdletBinding()]
+            param(
+                [Parameter(Mandatory = $true)]
+                [string]$Uri
+            )
+
+            $items = [System.Collections.Generic.List[object]]::new()
+            $nextUri = $Uri
+
+            while (-not [string]::IsNullOrWhiteSpace($nextUri)) {
+                $response = Invoke-MgGraphRequest -Method GET -Uri $nextUri -ErrorAction Stop
+
+                $pageItems = @()
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('value')) {
+                        $value = $response['value']
+                        if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                            foreach ($entry in $value) {
+                                if ($null -ne $entry) { $pageItems += $entry }
+                            }
+                        }
+                        elseif ($null -ne $value) {
+                            $pageItems = @($value)
+                        }
+                    }
+                    elseif (($response.Contains('id') -or $response.Contains('Id')) -and $null -ne $response) {
+                        $pageItems = @($response)
+                    }
+                }
+                elseif ($response -is [System.Array]) {
+                    $pageItems = @($response)
+                }
+                elseif ($response.PSObject.Properties.Name -contains 'value') {
+                    $value = $response.value
+                    if ($value -is [System.Collections.IEnumerable] -and $value -isnot [string]) {
+                        foreach ($entry in $value) {
+                            if ($null -ne $entry) { $pageItems += $entry }
+                        }
+                    }
+                    elseif ($null -ne $value) {
+                        $pageItems = @($value)
+                    }
+                }
+                elseif ((($response.PSObject.Properties.Name -contains 'id') -or ($response.PSObject.Properties.Name -contains 'Id')) -and $null -ne $response) {
+                    $pageItems = @($response)
+                }
+
+                foreach ($item in $pageItems) {
+                    $items.Add($item) | Out-Null
+                }
+
+                $nextLink = $null
+                if ($response -is [System.Collections.IDictionary]) {
+                    if ($response.Contains('@odata.nextLink')) {
+                        $nextLink = [string]$response['@odata.nextLink']
+                    }
+                }
+                else {
+                    $nextLinkProperty = $response.PSObject.Properties['@odata.nextLink']
+                    if ($nextLinkProperty) {
+                        $nextLink = [string]$nextLinkProperty.Value
+                    }
+                }
+
+                if (-not [string]::IsNullOrWhiteSpace($nextLink)) {
+                    $nextUri = $nextLink
+                }
+                else {
+                    $nextUri = $null
+                }
+            }
+
+            return $items.ToArray()
+        }
+    }
+
+    process {
+        $graphConnected = Test-MgGraphConnection -Scopes @('DeviceManagementConfiguration.Read.All', 'Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+        if (-not $graphConnected) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+            return
+        }
+
+        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+            return
+        }
+
+        $assignmentEndpoints = @(
+            "beta/deviceManagement/deviceConfigurations('$ProfileId')/assignments?`$top=100",
+            "v1.0/deviceManagement/deviceConfigurations('$ProfileId')/assignments?`$top=100",
+            "beta/deviceManagement/configurationPolicies('$ProfileId')/assignments?`$top=100",
+            "beta/deviceManagement/groupPolicyConfigurations('$ProfileId')/assignments?`$top=100",
+            "beta/deviceManagement/resourceAccessProfiles('$ProfileId')/assignments?`$top=100"
+        )
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        foreach ($endpoint in $assignmentEndpoints) {
+            $assignments = @()
+            try {
+                $assignments = @(Invoke-NCRawAssignmentCollectionRequest -Uri $endpoint)
+            }
+            catch {
+                continue
+            }
+
+            foreach ($assignment in $assignments) {
+                $target = $null
+                if ($assignment -is [System.Collections.IDictionary]) {
+                    foreach ($key in @('target', 'Target')) {
+                        if ($assignment.Contains($key) -and $null -ne $assignment[$key]) {
+                            $target = $assignment[$key]
+                            break
+                        }
+                    }
+                }
+                elseif ($assignment.PSObject.Properties['Target']) {
+                    $target = $assignment.Target
+                }
+                elseif ($assignment.PSObject.Properties['target']) {
+                    $target = $assignment.PSObject.Properties['target'].Value
+                }
+
+                $targetProps = @{}
+                if ($target) {
+                    foreach ($prop in $target.PSObject.Properties) {
+                        if ($prop.Name -ne 'AdditionalProperties') {
+                            $targetProps[$prop.Name] = $prop.Value
+                        }
+                    }
+
+                    $additionalTargetProperties = $target.PSObject.Properties['AdditionalProperties']
+                    if ($additionalTargetProperties -and $additionalTargetProperties.Value) {
+                        foreach ($key in $additionalTargetProperties.Value.Keys) {
+                            $targetProps[$key] = $additionalTargetProperties.Value[$key]
+                        }
+                    }
+                }
+
+                $assignmentId = $null
+                if ($assignment -is [System.Collections.IDictionary]) {
+                    foreach ($key in @('id', 'Id')) {
+                        if ($assignment.Contains($key) -and -not [string]::IsNullOrWhiteSpace([string]$assignment[$key])) {
+                            $assignmentId = [string]$assignment[$key]
+                            break
+                        }
+                    }
+                }
+                elseif ($assignment.PSObject.Properties['Id']) {
+                    $assignmentId = $assignment.Id
+                }
+                elseif ($assignment.PSObject.Properties['id']) {
+                    $assignmentId = $assignment.PSObject.Properties['id'].Value
+                }
+
+                $results.Add([pscustomobject][ordered]@{
+                        'Endpoint'         = $endpoint
+                        'Assignment Id'    = $assignmentId
+                        'Target Summary'   = ($targetProps.GetEnumerator() | Sort-Object Name | ForEach-Object { "{0}={1}" -f $_.Name, $_.Value }) -join '; '
+                        'Target Properties' = [pscustomobject]$targetProps
+                    }) | Out-Null
+            }
+        }
+
+        Add-EmptyLine
+        Write-NCMessage "Raw assignment rows found for '$ProfileId': $($results.Count)" -Level VERBOSE
+
+        if ($results.Count -eq 0) {
+            Write-NCMessage "No raw assignments found for '$ProfileId' in the probed endpoints." -Level WARNING
+            return
+        }
+
+        $sorted = $results | Sort-Object 'Endpoint', 'Assignment Id' -Unique
+        if ($GridView.IsPresent) {
+            $sorted | Out-GridView -Title "Intune Raw Assignments - $ProfileId"
+        }
+        else {
+            $sorted
+        }
+    }
+}

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -175,7 +175,7 @@ function Search-IntuneProfileLocation {
         }
 
         Add-EmptyLine
-        Write-NCMessage "Intune profiles found for '$normalizedSearch': $($results.Count)" -Level VERBOSE
+        Write-Verbose "Intune profiles found for '$normalizedSearch': $($results.Count)"
 
         if ($results.Count -eq 0) {
             Write-NCMessage "No Intune profiles found for '$normalizedSearch' in the currently scanned endpoints." -Level WARNING
@@ -294,13 +294,16 @@ function Export-IntuneAppInventory {
 
             foreach ($device in $devices) {
                 $processed++
-                Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
+
+                $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+
                 try {
                     $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
                     $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET -ErrorAction Stop
                     
                     foreach ($app in ($deviceWithApps.detectedApps | Where-Object { $_.displayName -like $ApplicationName })) {
-                        Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName) | App: $($app.displayName)" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
+                        Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) / $($app.displayName) ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
                         if ($MinimumVersion -and $app.version) {
                             if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
                                 continue
@@ -318,7 +321,7 @@ function Export-IntuneAppInventory {
                             Platform   = $device.operatingSystem
                             User       = $device.userPrincipalName
                             Version    = $app.version
-                            # Publisher  = $app.publisher
+                            Publisher  = $app.publisher
                             Source     = "DetectedApps"
                         }
                         
@@ -337,7 +340,10 @@ function Export-IntuneAppInventory {
                         Write-NCMessage "`nRate limit hit, waiting 60 seconds ..." -Level INFO
                         Start-Sleep -Seconds 60
                         $processed--
-                        Write-Progress -Activity "Reading Detected Apps" -Status "$processed / $($devices.Count) devices" -CurrentOperation "Waiting after rate limit" -PercentComplete (($processed / [Math]::Max($devices.Count,1)) * 100)
+
+                        $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
+                        Write-Progress -Activity "Reading Detected Apps" -Status "Waiting after rate limit ... ($processed / $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
+
                         continue
                     }
                     Write-NCMessage "Error reading apps for $($device.deviceName): $($_.Exception.Message)" -Level WARNING
@@ -384,9 +390,9 @@ function Export-IntuneAppInventory {
                                 Platform     = $d.operatingSystem
                                 User         = $d.userPrincipalName
                                 Version      = $null
-                                # Publisher    = $null
-                                # InstallState = $s.installState
-                                # AppType      = $appType
+                                Publisher    = $null
+                                InstallState = $s.installState
+                                AppType      = $appType
                                 Source       = "DeploymentStatus"
                             }
                         }
@@ -396,7 +402,7 @@ function Export-IntuneAppInventory {
 
             # Optional app type filter when only Detected Apps were used
             if (-not $IncludeDeployedApps -and $FilterByType -ne "All") {
-                Write-NCMessage "FilterByType applies only when -IncludeDeployedApps is used. Skipping type filter for Detected Apps only." -Level VERBOSE
+                Write-Verbose "FilterByType applies only when -IncludeDeployedApps is used. Skipping type filter for Detected Apps only."
             }
 
             # Build flat rows
@@ -406,13 +412,13 @@ function Export-IntuneAppInventory {
                     $rows += [pscustomobject]@{
                         AppName      = $appName
                         Version      = $dev.Version
-                        # Publisher    = $dev.Publisher
-                        # AppType      = $dev.AppType
+                        Publisher    = $dev.Publisher
+                        AppType      = $dev.AppType
                         DeviceName   = $dev.DeviceName
                         DeviceId     = $dev.DeviceId
                         Platform     = $dev.Platform
                         User         = $dev.User
-                        # InstallState = $dev.InstallState
+                        InstallState = $dev.InstallState
                         Source       = $dev.Source
                     }
                 }
@@ -424,7 +430,7 @@ function Export-IntuneAppInventory {
             }
 
             # Console table output
-            $rows | Sort-Object AppName, DeviceName | Format-Table -AutoSize AppName, Version, Publisher, AppType, DeviceName, Platform, User, InstallState, Source
+            $rows | Sort-Object AppName, DeviceName | Format-Table -AutoSize AppName, Version, DeviceName, Platform, User, Source
 
             # Optional exports
             if ($OutputCsvPath) {
@@ -458,6 +464,8 @@ function Export-IntuneAppInventory {
                     "• {0}: {1} devices`n    Versions: {2}`n    Top publishers: {3}" -f $app, $count, ($(if ($versions) { $versions } else { 'n/a' })), ($(if ($publishers) { $publishers } else { 'n/a' }))
                 }
             }
+
+            Write-NCMessage "App inventory report completed successfully." -Level SUCCESS
         }
         catch {
             Write-NCMessage "Script execution failed: $($_.Exception.Message)" -Level ERROR
@@ -565,15 +573,15 @@ function New-IntuneAppBasedGroup {
 
             $useExplicitGroupName = -not [string]::IsNullOrWhiteSpace($GroupName)
             if ($useExplicitGroupName -and ($PSBoundParameters.ContainsKey('GroupPrefix') -or $PSBoundParameters.ContainsKey('GroupSuffix'))) {
-                Write-NCMessage 'GroupName was supplied; GroupPrefix and GroupSuffix will be ignored.' -Level VERBOSE
+                Write-Verbose 'GroupName was supplied; GroupPrefix and GroupSuffix will be ignored.'
             }
 
             Write-NCMessage "Starting app-based group creation process ..." -Level INFO
 
             Write-NCMessage "Retrieving managed devices ..." -Level INFO
-            $devicesUri = 'https://graph.microsoft.com/v1.0/deviceManagement/managedDevices'
+            $devicesUri = 'https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$select=id,deviceName,operatingSystem,userPrincipalName,azureADDeviceId,azureActiveDirectoryDeviceId'
             if ($MaxDevices -gt 0) {
-                $devicesUri += "?`$top=$MaxDevices"
+                $devicesUri += "&`$top=$MaxDevices"
             }
 
             $devices = @(Invoke-NCGraphAllPagesCore -Uri $devicesUri)
@@ -589,16 +597,18 @@ function New-IntuneAppBasedGroup {
             Write-NCMessage "Processing device applications ..." -Level INFO
             foreach ($device in $devices) {
                 $processedDevices++
-                Write-Progress -Activity 'Processing Devices' -Status "$processedDevices of $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName)" -PercentComplete (($processedDevices / [Math]::Max($devices.Count, 1)) * 100)
+
+                $Percentage = [Math]::Round(($processedDevices / [Math]::Max($devices.Count, 1)) * 100, 2)
+                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) ($processedDevices of $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
 
                 try {
-                    $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$expand=detectedApps"
+                    $deviceAppsUri = "https://graph.microsoft.com/beta/deviceManagement/managedDevices/$($device.id)?`$select=id,deviceName,operatingSystem,userPrincipalName,azureADDeviceId,azureActiveDirectoryDeviceId&`$expand=detectedApps"
                     $deviceWithApps = Invoke-MgGraphRequest -Uri $deviceAppsUri -Method GET
 
                     if ($deviceWithApps.detectedApps) {
                         foreach ($app in $deviceWithApps.detectedApps) {
                             if ($app.displayName -like $ApplicationName) {
-                                Write-Progress -Activity 'Processing Devices' -Status "$processedDevices of $($devices.Count) devices" -CurrentOperation "Device: $($device.deviceName) | App: $($app.displayName)" -PercentComplete (($processedDevices / [Math]::Max($devices.Count, 1)) * 100)
+                                Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) / $($app.displayName) ($processedDevices of $($devices.Count) devices - $Percentage%)" -PercentComplete $Percentage
 
                                 if ($MinimumVersion -and $app.version) {
                                     if (-not (Test-NCIntuneVersionAtLeast -CurrentVersion $app.version -MinimumVersion $MinimumVersion)) {
@@ -712,7 +722,7 @@ function New-IntuneAppBasedGroup {
                 }
             }
             elseif ($FilterByType -ne 'All') {
-                Write-NCMessage 'FilterByType applies only when deployment data is used. Skipping type filter for detected apps only.' -Level VERBOSE
+                Write-Verbose 'FilterByType applies only when deployment data is used. Skipping type filter for detected apps only.'
             }
 
             Write-NCMessage "Processing groups for $($appDeviceMap.Count) applications ..." -Level INFO
@@ -766,8 +776,13 @@ function New-IntuneAppBasedGroup {
                 $processedApps++
                 $appName = $target.AppName
                 $appInfo = $target
-                $uniqueDevices = $appInfo.Devices | Select-Object -Property DeviceId -Unique
-                $deviceCount = $uniqueDevices.Count
+                $uniqueDeviceIds = @(
+                    $appInfo.Devices |
+                        ForEach-Object { Get-NCCoreProperty -Object $_ -Names @('DeviceId', 'deviceId', 'Id', 'id') } |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+                        Select-Object -Unique
+                )
+                $deviceCount = $uniqueDeviceIds.Count
 
                 if ($deviceCount -eq 0) {
                     continue
@@ -781,7 +796,10 @@ function New-IntuneAppBasedGroup {
                     $groupName = Get-NCIntuneAppBasedGroupName -AppName $appName -GroupPrefix $GroupPrefix -GroupSuffix $GroupSuffix
                     $groupDescription = "Devices with $appName installed (Created via Nebula.Core)"
                 }
-                Write-Progress -Activity 'Processing App Groups' -Status "$processedApps of $($groupTargets.Count) groups" -CurrentOperation "App: $appName | Group: $groupName" -PercentComplete (($processedApps / [Math]::Max($groupTargets.Count, 1)) * 100)
+
+                $Percentage = ($processedApps / [Math]::Max($groupTargets.Count, 1)) * 100
+                Write-Progress -Activity 'Processing App Groups' -Status "$appName / $groupName ($processedApps of $($groupTargets.Count) groups - $Percentage%)" -PercentComplete $Percentage
+
                 if ($DryRun.IsPresent) {
                     Write-NCMessage "[DRY RUN] Would create/update group: $groupName" -Level INFO
                     Write-NCMessage "Total devices with app matches: $deviceCount" -Level INFO
@@ -816,45 +834,26 @@ function New-IntuneAppBasedGroup {
                 $entraDevices = @()
                 $processedMembers = 0
 
-                foreach ($device in $uniqueDevices) {
+                foreach ($deviceId in $uniqueDeviceIds) {
                     $processedMembers++
 
                     try {
-                        $intuneDevice = $devices | Where-Object { $_.id -eq $device.DeviceId } | Select-Object -First 1
-                        $deviceLabel = if ($intuneDevice -and -not [string]::IsNullOrWhiteSpace($intuneDevice.deviceName)) {
-                            $intuneDevice.deviceName
-                        }
-                        else {
-                            $device.DeviceId
-                        }
+                        $Percentage = [Math]::Round(($processedMembers / [Math]::Max($uniqueDeviceIds.Count, 1)) * 100, 2)
+                        $resolution = Resolve-NCIntuneManagedDeviceEntraMember -ManagedDevices $devices -DeviceId $deviceId
+                        $deviceLabel = if ($resolution -and -not [string]::IsNullOrWhiteSpace($resolution.DeviceName)) { $resolution.DeviceName } else { [string]$deviceId }
+                        Write-Progress -Activity 'Resolving Entra Devices' -Status "$deviceLabel ($processedMembers of $($uniqueDeviceIds.Count) devices - $Percentage%)" -PercentComplete $Percentage
 
-                        Write-Progress -Activity 'Resolving Entra Devices' -Status "$processedMembers of $($uniqueDevices.Count) devices" -CurrentOperation "Device: $deviceLabel" -PercentComplete (($processedMembers / [Math]::Max($uniqueDevices.Count, 1)) * 100)
-
-                        if ($intuneDevice -and $intuneDevice.azureADDeviceId) {
-                            $filter = "deviceId eq '$($intuneDevice.azureADDeviceId)'"
-                            $entraDeviceUri = "https://graph.microsoft.com/v1.0/devices?`$filter=$filter"
-                            $entraDeviceResponse = Invoke-MgGraphRequest -Uri $entraDeviceUri -Method GET
-
-                            if ($entraDeviceResponse.value -and $entraDeviceResponse.value.Count -gt 0) {
-                                $entraDevice = $entraDeviceResponse.value[0]
-                                $memberIds += "https://graph.microsoft.com/v1.0/directoryObjects/$($entraDevice.id)"
-                                $entraDevices += @{
-                                    IntuneDeviceId = $device.DeviceId
-                                    EntraDeviceId  = $entraDevice.id
-                                    DeviceName     = $intuneDevice.deviceName
-                                }
-                                Write-NCMessage "Found Entra ID device: $($intuneDevice.deviceName) -> $($entraDevice.id)" -Level VERBOSE
+                        if ($resolution) {
+                            $memberIds += "https://graph.microsoft.com/v1.0/directoryObjects/$($resolution.EntraDeviceId)"
+                            $entraDevices += @{
+                                IntuneDeviceId = $resolution.IntuneDeviceId
+                                EntraDeviceId  = $resolution.EntraDeviceId
+                                DeviceName     = $resolution.DeviceName
                             }
-                            else {
-                                Write-NCMessage "Device not found in Entra ID: $($intuneDevice.deviceName) (Azure AD Device ID: $($intuneDevice.azureADDeviceId))" -Level WARNING
-                            }
-                        }
-                        else {
-                            Write-NCMessage "No Azure AD Device ID for: $($intuneDevice.deviceName)" -Level WARNING
                         }
                     }
                     catch {
-                        Write-NCMessage "Error looking up Entra ID device for $($intuneDevice.deviceName): $($_.Exception.Message)" -Level ERROR
+                        Write-NCMessage "Error looking up Entra ID device for $($deviceId): $($_.Exception.Message)" -Level ERROR
                     }
                 }
 
@@ -952,7 +951,7 @@ function New-IntuneAppBasedGroup {
                         }
                         catch {
                             Write-NCMessage "Failed to create group: $($_.Exception.Message)" -Level ERROR
-                            Write-NCMessage "Group body: $groupBody" -Level VERBOSE
+                            Write-Verbose "Group body: $groupBody"
                         }
                     }
                 }

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -925,8 +925,7 @@ function New-IntuneAppBasedGroup {
                             } | ConvertTo-Json -Depth 10
 
                             $newGroup = Invoke-MgGraphRequest -Uri 'https://graph.microsoft.com/v1.0/groups' -Method POST -Body $groupBody -ContentType 'application/json'
-                            Write-NCMessage "Created group: $groupName" -Level SUCCESS
-                            Write-NCMessage "Group ID: $($newGroup.id)" -Level INFO
+                            Write-NCMessage "Created group: $groupName $($newGroup.id)" -Level SUCCESS
 
                             if ($memberIds.Count -gt 0) {
                                 try {
@@ -968,17 +967,18 @@ function New-IntuneAppBasedGroup {
 
             Write-Progress -Activity 'Processing App Groups' -Completed
 
-            Add-EmptyLine
-            Write-NCMessage " - Applications matched: $($appDeviceMap.Count)" -Level INFO
-            Write-NCMessage " - Total devices processed: $totalDevicesProcessed" -Level INFO
-            Write-NCMessage " - Groups created: $groupsCreated" -Level INFO
-            Write-NCMessage " - Groups updated: $groupsUpdated" -Level INFO
+            # Add-EmptyLine
+            # Write-NCMessage " - Applications matched: $($appDeviceMap.Count)" -Level INFO
+            # Write-NCMessage " - Total devices processed: $totalDevicesProcessed" -Level INFO
+            # Write-NCMessage " - Groups created: $groupsCreated" -Level INFO
+            # Write-NCMessage " - Groups updated: $groupsUpdated" -Level INFO
 
             if ($DryRun.IsPresent) {
                 Write-NCMessage "[DRY RUN] No changes were made" -Level INFO
             }
 
             if ($appDeviceMap.Count -gt 0) {
+                Add-EmptyLine
                 Write-NCMessage "Top Applications by Device Count:" -Level INFO
                 $appDeviceMap.GetEnumerator() |
                     Sort-Object { if ($_.Value.DeviceIds) { $_.Value.DeviceIds.Count } else { $_.Value.Devices.Count } } -Descending |
@@ -990,6 +990,7 @@ function New-IntuneAppBasedGroup {
                     }
             }
 
+            Add-EmptyLine
             Write-NCMessage "App-based group creation completed successfully." -Level SUCCESS
         }
         catch {

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -486,6 +486,9 @@ function Export-MsolAccountSku {
         maps SKU part numbers to friendly names, and writes/resumes a CSV report.
     .PARAMETER CSVFolder
         Output folder (defaults to the current directory if omitted).
+    .PARAMETER Domain
+        Optional domain filter. When specified, only users whose Mail, UserPrincipalName,
+        or ProxyAddresses belong to that domain are exported.
     .PARAMETER ForceLicenseCatalogRefresh
         Force a fresh download of the cached license catalog before processing.
     .PARAMETER ShowErrorDetails
@@ -494,11 +497,14 @@ function Export-MsolAccountSku {
         Export-MsolAccountSku
     .EXAMPLE
         Export-MsolAccountSku -CsvFolder "C:\Temp"
+    .EXAMPLE
+        Export-MsolAccountSku -Domain "contoso.com"
     #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $True, HelpMessage = "Folder where export CSV file (e.g. C:\Temp)")]
         [string]$CSVFolder,
+        [string]$Domain,
         [switch]$ForceLicenseCatalogRefresh
     )
 
@@ -527,6 +533,64 @@ function Export-MsolAccountSku {
         $maxAttempts = 3
         $resolvedViaCustom = @{}
         $unknownSkuTracker = @{}
+        $normalizedDomain = $null
+        if (-not [string]::IsNullOrWhiteSpace($Domain)) {
+            $normalizedDomain = $Domain.Trim().ToLowerInvariant().TrimStart('@')
+            if ([string]::IsNullOrWhiteSpace($normalizedDomain)) {
+                Write-NCMessage "Domain filter cannot be empty." -Level ERROR
+                return
+            } else {
+                Write-NCMessage "Filtering users for domain '$normalizedDomain'." -Level VERBOSE
+            }
+        }
+
+        $getAddressDomain = {
+            param($value)
+
+            if ([string]::IsNullOrWhiteSpace($value)) {
+                return $null
+            }
+
+            $address = [string]$value
+            if ($address.Contains(':')) {
+                $address = $address.Substring($address.IndexOf(':') + 1)
+            }
+
+            $atIndex = $address.LastIndexOf('@')
+            if ($atIndex -lt 0 -or $atIndex -eq ($address.Length - 1)) {
+                return $null
+            }
+
+            return $address.Substring($atIndex + 1).Trim().ToLowerInvariant()
+        }
+
+        $matchesDomain = {
+            param($user)
+
+            if (-not $normalizedDomain) {
+                return $true
+            }
+
+            $domains = @()
+
+            foreach ($candidate in @($user.Mail, $user.UserPrincipalName)) {
+                $candidateDomain = & $getAddressDomain $candidate
+                if ($candidateDomain) {
+                    $domains += $candidateDomain
+                }
+            }
+
+            if ($user.PSObject.Properties['ProxyAddresses'] -and $user.ProxyAddresses) {
+                foreach ($proxy in $user.ProxyAddresses) {
+                    $proxyDomain = & $getAddressDomain $proxy
+                    if ($proxyDomain) {
+                        $domains += $proxyDomain
+                    }
+                }
+            }
+
+            return ($domains | Select-Object -Unique) -contains $normalizedDomain
+        }
 
         $CSV = New-File("$($folder)\$((Get-Date -Format $($NCVars.DateTimeString_CSV)).ToString())_M365-User-License-Report.csv")
         if (Test-Path $CSV) {
@@ -537,11 +601,20 @@ function Export-MsolAccountSku {
         }
 
         try {
-            $Users = Get-MgUser -Filter 'assignedLicenses/$count ne 0' -ConsistencyLevel eventual -CountVariable totalUsers -All -ErrorAction Stop
+            $Users = Get-MgUser -Filter 'assignedLicenses/$count ne 0' -ConsistencyLevel eventual -CountVariable totalUsers -All -Property Id,DisplayName,UserPrincipalName,Mail,ProxyAddresses -ErrorAction Stop
         }
         catch {
             Write-NCMessage "Failed to retrieve users with assigned licenses: $_" -Level ERROR
             return
+        }
+
+        if ($normalizedDomain) {
+            $Users = $Users | Where-Object { & $matchesDomain $_ }
+            $totalUsers = @($Users).Count
+            if ($totalUsers -eq 0) {
+                Write-NCMessage "No licensed users match domain '$normalizedDomain'." -Level WARNING
+                return
+            }
         }
 
         foreach ($User in $Users) {
@@ -578,7 +651,7 @@ function Export-MsolAccountSku {
                         -MatchSource ([ref]$matchSource)
 
                     if (-not $productName) {
-                        Write-Verbose "Unknown license: $licenseSku for $($User.UserPrincipalName)"
+                        Write-NCMessage "Unknown license: $licenseSku for $($User.UserPrincipalName)" -Level VERBOSE
                         if ($unknownSkuTracker.ContainsKey($licenseSku)) {
                             $unknownSkuTracker[$licenseSku]++
                         }
@@ -1025,7 +1098,7 @@ function Get-UserMsolAccountSku {
                     Write-NCMessage ("  - {0}{2} ({1})" -f $display, $skuId, $suffix) -Level INFO
                 }
                 else {
-                    Write-Verbose ("  - Unknown license: {0} ({1})" -f $skuPart, $skuId)
+                    Write-NCMessage ("  - Unknown license: {0} ({1})" -f $skuPart, $skuId) -Level VERBOSE
                     Write-NCMessage ("  - {0} ({1})" -f $skuPart, $skuId) -Level WARNING
                 }
 

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Licenses =============================================================================================================================
+# Nebula.Core: Licenses helpers =====================================================================================================================
 
 function Add-UserMsolAccountSku {
     <#
@@ -49,7 +49,7 @@ function Add-UserMsolAccountSku {
             return
         }
 
-        $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $UserPrincipalName
+        $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $UserPrincipalName -PreferGraphIdentity
         if (-not $resolvedPrincipal) {
             Write-NCMessage "Unable to resolve user recipient for $UserPrincipalName" -Level ERROR
             return
@@ -276,8 +276,8 @@ function Copy-UserMsolAccountSku {
             return
         }
 
-        $resolvedSource = Find-UserRecipient -UserPrincipalName $SourceUserPrincipalName
-        $resolvedDestination = Find-UserRecipient -UserPrincipalName $DestinationUserPrincipalName
+        $resolvedSource = Find-UserRecipient -UserPrincipalName $SourceUserPrincipalName -PreferGraphIdentity
+        $resolvedDestination = Find-UserRecipient -UserPrincipalName $DestinationUserPrincipalName -PreferGraphIdentity
 
         try {
             if ($resolvedSource) {
@@ -893,6 +893,7 @@ function Get-UserMsolAccountSku {
         Set-ProgressAndInfoPreferences
         $initSucceeded = $true
         $clipboardLines = @()
+        $clipboardHasContent = $false
         $availabilityBySkuId = @{}
 
         try {
@@ -975,16 +976,16 @@ function Get-UserMsolAccountSku {
 
     process {
         if (-not $initSucceeded) { return }
-
+        
         $inputUserPrincipalName = $UserPrincipalName
-        $resolvedRecipient = Find-UserRecipient -UserPrincipalName $inputUserPrincipalName
-        if (-not $resolvedRecipient) {
+        $resolvedGraphIdentity = Find-UserRecipient -UserPrincipalName $inputUserPrincipalName -PreferGraphIdentity
+        if (-not $resolvedGraphIdentity) {
             Write-NCMessage "Unable to resolve user recipient for $inputUserPrincipalName" -Level ERROR
             return
         }
 
         try {
-            $User = Get-MgUser -UserId $resolvedRecipient -ErrorAction Stop
+            $User = Get-MgUser -UserId $resolvedGraphIdentity -Property Id, DisplayName, UserPrincipalName, Mail -ErrorAction Stop
         }
         catch {
             $detail = if ($ShowErrorDetails.IsPresent) { ": $($_.Exception.Message)" } else { "." }
@@ -1048,18 +1049,18 @@ function Get-UserMsolAccountSku {
             if ($Clipboard.IsPresent) {
                 $normalized = $licensesForClipboard | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
                 $quoted = $normalized | ForEach-Object { "`"$($_.Replace('"', '\"'))`"" }
-                $clipboardLines += ($quoted -join ",")
+                if ((@($quoted)).Count -gt 0) {
+                    $clipboardLines += ($quoted -join ",")
+                    $clipboardHasContent = $true
+                }
             }
         }
         else {
             Write-NCMessage "No licenses assigned to this user." -Level VERBOSE
-            if ($Clipboard.IsPresent) {
-                $clipboardLines += ''
-            }
         }
     }
     end {
-        if ($Clipboard.IsPresent) {
+        if ($Clipboard.IsPresent -and $clipboardHasContent) {
             $clipboardText = ($clipboardLines -join [Environment]::NewLine)
             try {
                 $clipboardText | Set-Clipboard
@@ -1069,6 +1070,10 @@ function Get-UserMsolAccountSku {
             catch {
                 Write-NCMessage "Unable to copy license list to clipboard: $($_.Exception.Message)" -Level WARNING
             }
+        }
+        elseif ($Clipboard.IsPresent) {
+            Add-EmptyLine
+            Write-NCMessage "No license data available to copy to clipboard." -Level WARNING
         }
 
         Add-EmptyLine
@@ -1109,8 +1114,8 @@ function Move-UserMsolAccountSku {
             return
         }
 
-        $resolvedSource = Find-UserRecipient -UserPrincipalName $SourceUserPrincipalName
-        $resolvedDestination = Find-UserRecipient -UserPrincipalName $DestinationUserPrincipalName
+        $resolvedSource = Find-UserRecipient -UserPrincipalName $SourceUserPrincipalName -PreferGraphIdentity
+        $resolvedDestination = Find-UserRecipient -UserPrincipalName $DestinationUserPrincipalName -PreferGraphIdentity
 
         if (-not $resolvedSource) {
             Write-NCMessage "Unable to resolve source user recipient for $SourceUserPrincipalName" -Level ERROR
@@ -1377,7 +1382,7 @@ function Remove-UserMsolAccountSku {
             return
         }
 
-        $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $UserPrincipalName
+        $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $UserPrincipalName -PreferGraphIdentity
         if (-not $resolvedPrincipal) {
             Write-NCMessage "Unable to resolve user recipient for $UserPrincipalName" -Level ERROR
             return

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -747,7 +747,7 @@ function Export-MsolAccountSku {
         foreach ($User in $Users) {
             $ProcessedCount++
             $Percentage = [Math]::Round(($ProcessedCount / [Math]::Max($totalUsers, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers - $Percentage%" -PercentComplete $Percentage
 
             if ($ProcessedUsers -contains $User.UserPrincipalName) {
                 Write-NCMessage "Skipping $($User.UserPrincipalName), already processed." -Level WARNING
@@ -889,7 +889,9 @@ function Get-TenantMsolAccountSku {
     .PARAMETER Filter
         Filters the output to licenses whose name or SkuPartNumber contains the provided text.
     .PARAMETER SampleUsers
-        Returns up to N sample users for each matching SKU (requires -Filter). Defaults to 5 when specified.
+        Returns up to N sample users for each matching SKU (requires -Filter).
+    .PARAMETER IncludeSampleUsers
+        Returns sample users using the default limit of 5 (requires -Filter).
     .PARAMETER AsTable
         Display the result as a formatted table instead of returning objects.
     .PARAMETER GridView
@@ -902,12 +904,15 @@ function Get-TenantMsolAccountSku {
         Get-TenantMsolAccountSku -Filter "E3"
     .EXAMPLE
         Get-TenantMsolAccountSku -Filter "E3" -SampleUsers 5
+    .EXAMPLE
+        Get-TenantMsolAccountSku -Filter "E3" -IncludeSampleUsers
     #>
     [CmdletBinding()]
     param(
         [switch]$ForceLicenseCatalogRefresh,
         [string]$Filter,
         [int]$SampleUsers = 5,
+        [switch]$IncludeSampleUsers,
         [switch]$AsTable,
         [switch]$GridView
     )
@@ -953,7 +958,8 @@ function Get-TenantMsolAccountSku {
             return
         }
 
-        $useSampleUsers = $PSBoundParameters.ContainsKey('SampleUsers')
+        $useSampleUsers = $PSBoundParameters.ContainsKey('SampleUsers') -or $IncludeSampleUsers.IsPresent
+        $sampleUserLimit = if ($PSBoundParameters.ContainsKey('SampleUsers')) { $SampleUsers } else { 5 }
 
         if ($useSampleUsers -and -not $Filter) {
             Write-NCMessage "SampleUsers requires -Filter to limit the query scope. Example: Get-TenantMsolAccountSku -Filter \"E3\" -SampleUsers 5" -Level ERROR
@@ -1007,7 +1013,7 @@ function Get-TenantMsolAccountSku {
         }
 
         if ($useSampleUsers) {
-            if ($SampleUsers -le 0) {
+            if ($sampleUserLimit -le 0) {
                 Write-NCMessage "SampleUsers must be greater than 0." -Level ERROR
                 return
             }
@@ -1017,7 +1023,7 @@ function Get-TenantMsolAccountSku {
                 try {
                     $examples = Invoke-NCRetry -Action {
                         Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
-                            -Top $SampleUsers `
+                            -Top $sampleUserLimit `
                             -ConsistencyLevel eventual `
                             -Property Id,UserPrincipalName,DisplayName `
                             -ErrorAction Stop
@@ -1033,7 +1039,7 @@ function Get-TenantMsolAccountSku {
                 }
 
                 if ($examples) {
-                    foreach ($entry in ($examples | Select-Object -First $SampleUsers)) {
+                    foreach ($entry in ($examples | Select-Object -First $sampleUserLimit)) {
                         if ($entry.UserPrincipalName) {
                             if ($entry.DisplayName) {
                                 # $sampleUserList += ("{0} <{1}>" -f $entry.DisplayName, $entry.UserPrincipalName)
@@ -1059,32 +1065,54 @@ function Get-TenantMsolAccountSku {
                     Warning       = $sku.Warning
                     Source        = $sku.Source
                     SampleUsers   = $sampleUserList
+                    SampleUsersText = if ($sampleUserList.Count -gt 0) { $sampleUserList -join [Environment]::NewLine } else { $null }
                 }
             }
         }
 
         if ($GridView.IsPresent) {
-            $sorted | Out-GridView -Title "M365 Tenant Licenses"
+            $summaryRows = $sorted | Select-Object Name, SkuPartNumber, Total, Consumed, Available
+            $summaryRows | Out-GridView -Title "M365 Tenant Licenses"
+
+            if ($useSampleUsers) {
+                $sampleRows = foreach ($sku in $sorted) {
+                    if ($sku.PSObject.Properties['SampleUsers'] -and $sku.SampleUsers) {
+                        foreach ($sampleUser in $sku.SampleUsers) {
+                            [pscustomobject][ordered]@{
+                                Name          = $sku.Name
+                                SkuPartNumber = $sku.SkuPartNumber
+                                SampleUser    = $sampleUser
+                            }
+                        }
+                    }
+                }
+
+                if ($sampleRows) {
+                    $sampleRows | Out-GridView -Title "M365 Tenant License Sample Users"
+                }
+            }
         }
         elseif ($AsTable.IsPresent) {
             $limited = $sorted | Select-Object @{
                     Name       = 'Name'
                     Expression = { Format-OutputString -Value $_.Name -MaxLength $NCVars.MaxFieldLength }
-                }, SkuPartNumber, Total, Consumed, Available, @{
-                    Name       = 'SampleUsers'
-                    Expression = {
-                        if ($_.PSObject.Properties['SampleUsers'] -and $_.SampleUsers) {
-                            ($_.SampleUsers -join '; ')
-                        }
-                        else {
-                            $null
-                        }
+                }, SkuPartNumber, Total, Consumed, Available
+            Show-Table -Rows $limited -AsTable
+
+            if ($useSampleUsers) {
+                Add-EmptyLine
+                foreach ($sku in $sorted) {
+                    if (-not ($sku.PSObject.Properties['SampleUsers'] -and $sku.SampleUsers)) {
+                        continue
                     }
+
+                    Write-NCMessage ("Sample users for {0} ({1}):" -f $sku.Name, $sku.SkuPartNumber) -Level INFO
+                    foreach ($sampleUser in $sku.SampleUsers) {
+                        Write-NCMessage ("  - {0}" -f $sampleUser) -Level INFO
+                    }
+                    Add-EmptyLine
                 }
-            if (-not $useSampleUsers) {
-            $limited = $limited | Select-Object Name, SkuPartNumber, Total, Consumed, Available
-        }
-        Show-Table -Rows $limited -AsTable
+            }
         }
         else {
             $sorted
@@ -1297,6 +1325,7 @@ function Get-UserMsolAccountSku {
         }
         else {
             Write-Verbose "No licenses assigned to this user."
+            Write-NCMessage ("No licenses assigned to user {0}." -f $User.UserPrincipalName) -Level WARNING
         }
     }
     end {

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -211,7 +211,7 @@ function Add-UserMsolAccountSku {
             try {
                 Update-MgUser -UserId $user.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
                 $user.UsageLocation = $targetUsage
-                Write-NCMessage "Usage location set to $targetUsage for $($user.UserPrincipalName)." -Level VERBOSE
+                Write-Verbose "Usage location set to $targetUsage for $($user.UserPrincipalName)."
             }
             catch {
                 Write-NCMessage "Unable to set usage location ($targetUsage) for $($user.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
@@ -331,7 +331,7 @@ function Copy-UserMsolAccountSku {
             try {
                 Update-MgUser -UserId $destinationUser.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
                 $destinationUser.UsageLocation = $targetUsage
-                Write-NCMessage "Usage location set to $targetUsage for $($destinationUser.UserPrincipalName)." -Level VERBOSE
+                Write-Verbose "Usage location set to $targetUsage for $($destinationUser.UserPrincipalName)."
             }
             catch {
                 Write-NCMessage "Unable to set usage location ($targetUsage) for $($destinationUser.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
@@ -407,7 +407,7 @@ function Copy-UserMsolAccountSku {
             }
 
             if ($destinationSkuIds -contains $parsedGuid) {
-                Write-NCMessage "Destination already has $($lic.SkuPartNumber); skipping add." -Level VERBOSE
+                Write-Verbose "Destination already has $($lic.SkuPartNumber); skipping add."
                 continue
             }
 
@@ -419,7 +419,7 @@ function Copy-UserMsolAccountSku {
                         $validatedDisabled += $plan
                     }
                     elseif (-not [string]::IsNullOrWhiteSpace($planString)) {
-                        Write-NCMessage "Skipping invalid disabled plan '$planString' for $($lic.SkuPartNumber)." -Level VERBOSE
+                        Write-Verbose "Skipping invalid disabled plan '$planString' for $($lic.SkuPartNumber)."
                     }
                 }
             }
@@ -489,6 +489,9 @@ function Export-MsolAccountSku {
     .PARAMETER Domain
         Optional domain filter. When specified, only users whose Mail, UserPrincipalName,
         or ProxyAddresses belong to that domain are exported.
+    .PARAMETER License
+        Optional license filter. When specified, only users who have at least one matching
+        license are exported, but all of their assigned licenses are still included in the report.
     .PARAMETER ForceLicenseCatalogRefresh
         Force a fresh download of the cached license catalog before processing.
     .PARAMETER ShowErrorDetails
@@ -499,12 +502,15 @@ function Export-MsolAccountSku {
         Export-MsolAccountSku -CsvFolder "C:\Temp"
     .EXAMPLE
         Export-MsolAccountSku -Domain "contoso.com"
+    .EXAMPLE
+        Export-MsolAccountSku -License "Exchange Online (Plan 1)"
     #>
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline = $True, HelpMessage = "Folder where export CSV file (e.g. C:\Temp)")]
         [string]$CSVFolder,
         [string]$Domain,
+        [string[]]$License,
         [switch]$ForceLicenseCatalogRefresh
     )
 
@@ -528,6 +534,28 @@ function Export-MsolAccountSku {
 
         $licenseLookup = $licenseCatalog.Lookup
         $customLookup = $licenseCatalog.CustomLookup
+        $tenantSkus = @()
+        if ($License) {
+            try {
+                $tenantSkus = Invoke-NCRetry -Action {
+                    Get-MgSubscribedSku -All -ErrorAction Stop
+                } -MaxAttempts 3 -DelaySeconds 5 -OperationDescription "retrieve tenant licenses" -OnError {
+                    param($attempt, $max, $err)
+                    $currentAttempt = if ($attempt) { $attempt } else { '?' }
+                    $currentMax = if ($max) { $max } else { 3 }
+                    Write-NCMessage "Failed to retrieve tenant licenses, attempt $currentAttempt of $currentMax." -Level ERROR
+                }
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve tenant licenses for license filtering." -Level ERROR
+                return
+            }
+
+            if (-not $tenantSkus -or $tenantSkus.Count -eq 0) {
+                Write-NCMessage "No tenant licenses available to filter on." -Level WARNING
+                return
+            }
+        }
         $arr_MsolAccountSku = @()
         $ProcessedCount = 0
         $maxAttempts = 3
@@ -540,7 +568,7 @@ function Export-MsolAccountSku {
                 Write-NCMessage "Domain filter cannot be empty." -Level ERROR
                 return
             } else {
-                Write-NCMessage "Filtering users for domain '$normalizedDomain'." -Level VERBOSE
+                Write-Verbose "Filtering users for domain '$normalizedDomain'."
             }
         }
 
@@ -562,6 +590,105 @@ function Export-MsolAccountSku {
             }
 
             return $address.Substring($atIndex + 1).Trim().ToLowerInvariant()
+        }
+
+        $normalizeText = {
+            param($value)
+
+            if ([string]::IsNullOrWhiteSpace($value)) {
+                return $null
+            }
+
+            return $value.Trim().ToUpperInvariant()
+        }
+
+        $resolveLicenseFilter = {
+            param(
+                [string[]]$RequestedLicenses,
+                $TenantSkus,
+                $Lookup,
+                $FallbackLookup
+            )
+
+            $resolved = @()
+            $unmatched = @()
+
+            $requestedItems = $RequestedLicenses |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_.Trim() } |
+                Select-Object -Unique
+
+            foreach ($entry in $requestedItems) {
+                $target = & $normalizeText $entry
+                $match = $null
+
+                foreach ($sku in $TenantSkus) {
+                    $skuIdString = [string]$sku.SkuId
+                    $skuIdNormalized = if ($skuIdString) { $skuIdString.ToUpperInvariant() } else { $null }
+                    $skuPart = & $normalizeText $sku.SkuPartNumber
+
+                    $display = $null
+                    $matchSource = $null
+                    if ($Lookup) {
+                        $display = Get-LicenseDisplayName -Lookup $Lookup -SkuPartNumber $sku.SkuPartNumber -FallbackLookup $FallbackLookup -MatchSource ([ref]$matchSource)
+                    }
+                    $displayNormalized = if ($display) { & $normalizeText $display } else { $null }
+
+                    if ($target -eq $skuPart -or $target -eq $skuIdNormalized -or ($displayNormalized -and $target -eq $displayNormalized)) {
+                        $match = [pscustomobject]@{
+                            SkuId         = $sku.SkuId
+                            SkuPartNumber = $sku.SkuPartNumber
+                            Name          = if ($display) { $display } else { $sku.SkuPartNumber }
+                        }
+                        break
+                    }
+                }
+
+                if ($match) {
+                    $resolved += $match
+                }
+                else {
+                    $unmatched += $entry
+                }
+            }
+
+            [pscustomobject]@{
+                Resolved  = $resolved
+                Unmatched = $unmatched
+            }
+        }
+
+        $licenseFilter = $null
+        $licenseFilterIds = @()
+        $licenseFilterParts = @()
+        $licenseFilterNames = @()
+        if ($License) {
+            $licenseFilter = & $resolveLicenseFilter $License $tenantSkus $licenseLookup $customLookup
+            if ($licenseFilter.Unmatched.Count -gt 0) {
+                Write-NCMessage ("Unable to resolve license filter(s): {0}" -f ($licenseFilter.Unmatched -join ', ')) -Level ERROR
+                return
+            }
+
+            $licenseFilterIds = @(
+                $licenseFilter.Resolved |
+                    ForEach-Object { ([string]$_.SkuId).ToUpperInvariant() } |
+                    Where-Object { $_ } |
+                    Select-Object -Unique
+            )
+            $licenseFilterParts = @(
+                $licenseFilter.Resolved |
+                    ForEach-Object { & $normalizeText $_.SkuPartNumber } |
+                    Where-Object { $_ } |
+                    Select-Object -Unique
+            )
+            $licenseFilterNames = @(
+                $licenseFilter.Resolved |
+                    ForEach-Object { $_.Name } |
+                    Where-Object { $_ } |
+                    Select-Object -Unique
+            )
+
+            Write-Verbose ("Filtering users by license(s): {0}" -f ($licenseFilterNames -join ', '))
         }
 
         $matchesDomain = {
@@ -619,17 +746,17 @@ function Export-MsolAccountSku {
 
         foreach ($User in $Users) {
             $ProcessedCount++
-            $PercentComplete = (($ProcessedCount / $totalUsers) * 100)
-            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers ($($PercentComplete.ToString('0.00'))%)" -PercentComplete $PercentComplete
+            $Percentage = [Math]::Round(($ProcessedCount / [Math]::Max($totalUsers, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers ($Percentage%)" -PercentComplete $Percentage
 
             if ($ProcessedUsers -contains $User.UserPrincipalName) {
                 Write-NCMessage "Skipping $($User.UserPrincipalName), already processed." -Level WARNING
                 continue
             }
 
-        try {
-            $GraphLicense = Invoke-NCRetry -Action {
-                Get-MgUserLicenseDetail -UserId $User.Id -ErrorAction Stop
+            try {
+                $GraphLicense = Invoke-NCRetry -Action {
+                    Get-MgUserLicenseDetail -UserId $User.Id -ErrorAction Stop
             } -MaxAttempts $maxAttempts -DelaySeconds 5 -OperationDescription "retrieve licenses for $($User.UserPrincipalName)" -OnError {
                 param($attempt, $max, $err)
                 $currentAttempt = if ($attempt) { $attempt } else { '?' }
@@ -642,34 +769,56 @@ function Export-MsolAccountSku {
                 continue
             }
 
+            $userMatchesLicenseFilter = -not $License
+            $userMatchedLicenseNames = @()
+            $userRows = @()
+
             if ($null -ne $GraphLicense) {
-                foreach ($licenseSku in $GraphLicense.SkuPartNumber) {
+                foreach ($licenseSku in $GraphLicense) {
                     $matchSource = $null
+                    $skuIdString = if ($licenseSku.SkuId) { [string]$licenseSku.SkuId } else { $null }
+                    $skuIdNormalized = if ($skuIdString) { $skuIdString.ToUpperInvariant() } else { $null }
+                    $skuPartNormalized = & $normalizeText $licenseSku.SkuPartNumber
+
                     $productName = Get-LicenseDisplayName -Lookup $licenseLookup `
-                        -SkuPartNumber $licenseSku `
+                        -SkuPartNumber $licenseSku.SkuPartNumber `
                         -FallbackLookup $customLookup `
                         -MatchSource ([ref]$matchSource)
 
                     if (-not $productName) {
-                        Write-NCMessage "Unknown license: $licenseSku for $($User.UserPrincipalName)" -Level VERBOSE
-                        if ($unknownSkuTracker.ContainsKey($licenseSku)) {
-                            $unknownSkuTracker[$licenseSku]++
+                        Write-Verbose "Unknown license: $($licenseSku.SkuPartNumber) for $($User.UserPrincipalName)"
+                        if ($unknownSkuTracker.ContainsKey($licenseSku.SkuPartNumber)) {
+                            $unknownSkuTracker[$licenseSku.SkuPartNumber]++
                         }
                         else {
-                            $unknownSkuTracker[$licenseSku] = 1
+                            $unknownSkuTracker[$licenseSku.SkuPartNumber] = 1
                         }
-                        $productName = $licenseSku
+                        $productName = $licenseSku.SkuPartNumber
                     }
                     elseif ($matchSource -and $matchSource -ne 'Primary') {
-                        if ($resolvedViaCustom.ContainsKey($licenseSku)) {
-                            $resolvedViaCustom[$licenseSku]++
+                        if ($resolvedViaCustom.ContainsKey($licenseSku.SkuPartNumber)) {
+                            $resolvedViaCustom[$licenseSku.SkuPartNumber]++
                         }
                         else {
-                            $resolvedViaCustom[$licenseSku] = 1
+                            $resolvedViaCustom[$licenseSku.SkuPartNumber] = 1
                         }
                     }
 
-                    $arr_MsolAccountSku += [pscustomobject]@{
+                    if ($License -and -not $userMatchesLicenseFilter) {
+                        if (($skuIdNormalized -and ($licenseFilterIds -contains $skuIdNormalized)) -or
+                            ($skuPartNormalized -and ($licenseFilterParts -contains $skuPartNormalized))) {
+                            $userMatchesLicenseFilter = $true
+                            $userMatchedLicenseNames += if ($productName) { $productName } else { $licenseSku.SkuPartNumber }
+                        }
+                    }
+                    elseif ($License) {
+                        if (($skuIdNormalized -and ($licenseFilterIds -contains $skuIdNormalized)) -or
+                            ($skuPartNormalized -and ($licenseFilterParts -contains $skuPartNormalized))) {
+                            $userMatchedLicenseNames += if ($productName) { $productName } else { $licenseSku.SkuPartNumber }
+                        }
+                    }
+
+                    $userRows += [pscustomobject]@{
                         DisplayName        = $User.DisplayName
                         UserPrincipalName  = $User.UserPrincipalName
                         PrimarySmtpAddress = $User.Mail
@@ -678,8 +827,26 @@ function Export-MsolAccountSku {
                 }
             }
 
+            if ($License -and -not $userMatchesLicenseFilter) {
+                continue
+            }
+
+            if ($License -and $userMatchedLicenseNames.Count -gt 0) {
+                $matchedNames = $userMatchedLicenseNames | Select-Object -Unique
+                $userRows = $userRows | ForEach-Object {
+                    $_ | Add-Member -NotePropertyName MatchedLicenses -NotePropertyValue ($matchedNames -join ', ') -PassThru
+                }
+            }
+            elseif ($License) {
+                $userRows = $userRows | ForEach-Object {
+                    $_ | Add-Member -NotePropertyName MatchedLicenses -NotePropertyValue $null -PassThru
+                }
+            }
+
+            $arr_MsolAccountSku += $userRows
+
             if ($ProcessedCount % 50 -eq 0) {
-                Write-NCMessage "Processed $ProcessedCount out of $totalUsers, saving partial results ..." -Level VERBOSE
+                Write-Verbose "Processed $ProcessedCount out of $totalUsers, saving partial results ..."
                 $arr_MsolAccountSku | Export-CSV $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding) -Append
             }
         }
@@ -1098,7 +1265,7 @@ function Get-UserMsolAccountSku {
                     Write-NCMessage ("  - {0}{2} ({1})" -f $display, $skuId, $suffix) -Level INFO
                 }
                 else {
-                    Write-NCMessage ("  - Unknown license: {0} ({1})" -f $skuPart, $skuId) -Level VERBOSE
+                    Write-Verbose ("  - Unknown license: {0} ({1})" -f $skuPart, $skuId)
                     Write-NCMessage ("  - {0} ({1})" -f $skuPart, $skuId) -Level WARNING
                 }
 
@@ -1129,7 +1296,7 @@ function Get-UserMsolAccountSku {
             }
         }
         else {
-            Write-NCMessage "No licenses assigned to this user." -Level VERBOSE
+            Write-Verbose "No licenses assigned to this user."
         }
     }
     end {
@@ -1231,7 +1398,7 @@ function Move-UserMsolAccountSku {
             try {
                 Update-MgUser -UserId $destinationUser.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
                 $destinationUser.UsageLocation = $targetUsage
-                Write-NCMessage "Usage location set to $targetUsage for $($destinationUser.UserPrincipalName)." -Level VERBOSE
+                Write-Verbose "Usage location set to $targetUsage for $($destinationUser.UserPrincipalName)."
             }
             catch {
                 Write-NCMessage "Unable to set usage location ($targetUsage) for $($destinationUser.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
@@ -1295,7 +1462,7 @@ function Move-UserMsolAccountSku {
                     $destinationSkuIds += $parsedSku
                 }
                 elseif (-not [string]::IsNullOrWhiteSpace([string]$sku)) {
-                    Write-NCMessage "Skipping invalid destination SkuId '$sku'." -Level VERBOSE
+                    Write-Verbose "Skipping invalid destination SkuId '$sku'."
                 }
             }
         }
@@ -1320,7 +1487,7 @@ function Move-UserMsolAccountSku {
 
             $removeSkuIds += $parsedGuid
             if ($destinationSkuIds -contains $parsedGuid) {
-                Write-NCMessage "Destination already has $($lic.SkuPartNumber); skipping add." -Level VERBOSE
+                Write-Verbose "Destination already has $($lic.SkuPartNumber); skipping add."
                 continue
             }
 
@@ -1332,7 +1499,7 @@ function Move-UserMsolAccountSku {
                         $validatedDisabled += $plan
                     }
                     elseif (-not [string]::IsNullOrWhiteSpace($planString)) {
-                        Write-NCMessage "Skipping invalid disabled plan '$planString' for $($lic.SkuPartNumber)." -Level VERBOSE
+                        Write-Verbose "Skipping invalid disabled plan '$planString' for $($lic.SkuPartNumber)."
                     }
                 }
             }

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Mailboxes ============================================================================================================================
+# Nebula.Core: Mailboxes helpers ====================================================================================================================
 
 function Add-MboxAlias {
     <#

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -1405,7 +1405,7 @@ function Test-SharedMailboxCompliance {
         }
 
         Add-EmptyLine
-        Write-NCMessage "Finding shared mailboxes..." -NoNewline
+        Write-NCMessage "Finding shared mailboxes ..." -NoNewline
         $mailboxes = Get-ExoMailbox -RecipientTypeDetails SharedMailbox -ResultSize Unlimited | Sort-Object DisplayName
         if (-not $mailboxes) {
             Write-NCMessage "No shared mailboxes found." -Level WARNING

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -323,7 +323,7 @@ function Export-MboxAlias {
 
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
             $primary = $recipient.PrimarySmtpAddress
             foreach ($address in $recipient.EmailAddresses | Where-Object { $_ -clike 'smtp*' }) {
@@ -403,7 +403,7 @@ function Export-MboxPermission {
         foreach ($mailbox in $mailboxes) {
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) - $Percentage%" -PercentComplete $Percentage
 
             $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity
             $sendAs = Get-RecipientPermission -Identity $exoMailbox.PrimarySmtpAddress -AccessRights SendAs | Where-Object { $_.Trustee.ToString() -ne 'NT AUTHORITY\SELF' -and $_.Trustee.ToString() -notlike 'S-1-5*' } | ForEach-Object { $_.Trustee.ToString() }
@@ -1213,7 +1213,7 @@ function Set-MboxLanguage {
 
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-            Write-Progress -Activity "Changing language to $Language" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Changing language to $Language" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
             try {
                 Set-MailboxRegionalConfiguration -Identity $address -LocalizeDefaultFolderName:$true -Language $Language -ErrorAction Stop
@@ -1278,7 +1278,7 @@ function Set-MboxRulesQuota {
 
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) - $Percentage%" -PercentComplete $Percentage
 
             try {
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -RulesQuota 256KB
@@ -1343,7 +1343,7 @@ function Set-SharedMboxCopyForSent {
 
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) - $Percentage%" -PercentComplete $Percentage
 
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -MessageCopyForSentAsEnabled $true
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -MessageCopyForSendOnBehalfEnabled $true
@@ -1412,7 +1412,8 @@ function Test-SharedMailboxCompliance {
             return
         }
 
-        Write-NCMessage (" {0} shared mailboxes found." -f $mailboxes.Count) -Level SUCCESS
+        $mailboxLabel = if ($mailboxes.Count -eq 1) { 'shared mailbox found' } else { 'shared mailboxes found' }
+        Write-NCMessage (" {0} {1}." -f $mailboxes.Count, $mailboxLabel) -Level SUCCESS
         $exoPlan1 = '9aaf7827-d63c-4b61-89c3-182f06f82e5c'
         $exoPlan2 = 'efb87545-963c-4e0d-99df-69c6916d9eb0'
         $report = [System.Collections.Generic.List[object]]::new()
@@ -1421,7 +1422,7 @@ function Test-SharedMailboxCompliance {
         foreach ($mbx in $mailboxes) {
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
-            Write-Progress -Activity "Checking $($mbx.DisplayName)" -Status "$counter of $($mailboxes.Count) ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Checking $($mbx.DisplayName)" -Status "$counter of $($mailboxes.Count) - $Percentage%" -PercentComplete $Percentage
 
             $logsFound = $false
             $exoPlan1Found = $false

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -921,7 +921,7 @@ function New-SharedMailbox {
 
     try {
         New-Mailbox -Name $SharedMailboxDisplayName -Alias $SharedMailboxAlias -Shared -PrimarySmtpAddress $SharedMailboxSMTPAddress -ErrorAction Stop
-        Write-NCMessage ("Set outgoing e-mail copy save for {0}" -f $SharedMailboxSMTPAddress) -Level INFO
+        Write-NCMessage ("`nSet outgoing e-mail copy save for {0}" -f $SharedMailboxSMTPAddress) -Level INFO
         Set-Mailbox -Identity $SharedMailboxSMTPAddress -MessageCopyForSentAsEnabled $true
         Set-Mailbox -Identity $SharedMailboxSMTPAddress -MessageCopyForSendOnBehalfEnabled $true
         Set-Mailbox -Identity $SharedMailboxSMTPAddress -RetainDeletedItemsFor 30

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -322,8 +322,8 @@ function Export-MboxAlias {
             }
 
             $counter++
-            $percentComplete = (($counter / $total) * 100)
-            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
             $primary = $recipient.PrimarySmtpAddress
             foreach ($address in $recipient.EmailAddresses | Where-Object { $_ -clike 'smtp*' }) {
@@ -402,8 +402,8 @@ function Export-MboxPermission {
         $counter = 0
         foreach ($mailbox in $mailboxes) {
             $counter++
-            $percentComplete = (($counter / $mailboxes.Count) * 100)
-            Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) ($Percentage%)" -PercentComplete $Percentage
 
             $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity
             $sendAs = Get-RecipientPermission -Identity $exoMailbox.PrimarySmtpAddress -AccessRights SendAs | Where-Object { $_.Trustee.ToString() -ne 'NT AUTHORITY\SELF' -and $_.Trustee.ToString() -notlike 'S-1-5*' } | ForEach-Object { $_.Trustee.ToString() }
@@ -1212,8 +1212,8 @@ function Set-MboxLanguage {
             if (-not $address) { continue }
 
             $counter++
-            $percentComplete = (($counter / $total) * 100)
-            Write-Progress -Activity "Changing language to $Language" -Status "$counter of $total ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+            Write-Progress -Activity "Changing language to $Language" -Status "$counter of $total ($Percentage%)" -PercentComplete $Percentage
 
             try {
                 Set-MailboxRegionalConfiguration -Identity $address -LocalizeDefaultFolderName:$true -Language $Language -ErrorAction Stop
@@ -1277,8 +1277,8 @@ function Set-MboxRulesQuota {
             }
 
             $counter++
-            $percentComplete = (($counter / $SourceMailbox.Count) * 100)
-            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($Percentage%)" -PercentComplete $Percentage
 
             try {
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -RulesQuota 256KB
@@ -1342,8 +1342,8 @@ function Set-SharedMboxCopyForSent {
                 }
 
                 $counter++
-                $percentComplete = (($counter / $SourceMailbox.Count) * 100)
-                Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -MessageCopyForSentAsEnabled $true
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -MessageCopyForSendOnBehalfEnabled $true
@@ -1420,8 +1420,8 @@ function Test-SharedMailboxCompliance {
 
         foreach ($mbx in $mailboxes) {
             $counter++
-            $percentComplete = (($counter / $mailboxes.Count) * 100)
-            Write-Progress -Activity "Checking $($mbx.DisplayName)" -Status "$counter of $($mailboxes.Count) ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
+            Write-Progress -Activity "Checking $($mbx.DisplayName)" -Status "$counter of $($mailboxes.Count) ($Percentage%)" -PercentComplete $Percentage
 
             $logsFound = $false
             $exoPlan1Found = $false

--- a/Public/NC.ModuleUpdates.ps1
+++ b/Public/NC.ModuleUpdates.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Module update checks (public) ========================================================================================================
+# Nebula.Core: Module update helpers ================================================================================================================
 
 function Get-NebulaModuleUpdates {
     <#

--- a/Public/NC.Quarantine.ps1
+++ b/Public/NC.Quarantine.ps1
@@ -519,8 +519,8 @@ function Get-QuarantineToRelease {
         $counter = 0
         foreach ($item in $selection) {
             $counter++
-            $percentComplete = (($counter / $selection.Count) * 100)
-            Write-Progress -Activity "Processing $($item.Subject)" -Status "$counter of $($selection.Count) ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($counter / [Math]::Max($selection.Count, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($item.Subject)" -Status "$counter of $($selection.Count) ($Percentage%)" -PercentComplete $Percentage
 
             if ($ReleaseSelected.IsPresent) {
                 if ($PSCmdlet.ShouldProcess($item.Subject, "Release quarantined message")) {
@@ -613,7 +613,7 @@ function Unlock-QuarantineFrom {
 
             try {
                 $messages = Get-QuarantineMessage -SenderAddress $currentSender -ErrorAction Stop | Where-Object { $_.ReleaseStatus -ne "Released" -and $null -ne $_.QuarantinedUser }
-                Write-NCMessage "Found $($messages.Count) message(s) from $currentSender not yet released." -Level VERBOSE
+                Write-Verbose "Found $($messages.Count) message(s) from $currentSender not yet released."
             }
             catch {
                 Write-NCMessage "Unable to retrieve messages for '$currentSender'. $($_.Exception.Message)" -Level ERROR
@@ -623,7 +623,7 @@ function Unlock-QuarantineFrom {
             foreach ($msg in $messages) {
                 if ($PSCmdlet.ShouldProcess($msg.Identity, "Release quarantined message")) {
                     try {
-                        Write-NCMessage "Trying to release $($msg.Identity) to $($msg.RecipientAddress)  ..." -Level VERBOSE
+                        Write-Verbose "Trying to release $($msg.Identity) to $($msg.RecipientAddress)  ..."
                         $releaseParams = @{
                             Identity            = $msg.Identity
                             ReleaseToAll        = $true
@@ -732,9 +732,9 @@ function Unlock-QuarantineMessageId {
 
             $processed++
             if ($targetCount -gt 1) {
-                $percentComplete = (($processed / $targetCount) * 100)
+                $Percentage = [Math]::Round(($processed / [Math]::Max($targetCount, 1)) * 100, 2)
                 $statusMessage = "$processed of $targetCount ($($msg.Identity))"
-                Write-Progress -Activity "Releasing quarantined messages" -Status $statusMessage -PercentComplete $percentComplete
+                Write-Progress -Activity "Releasing quarantined messages" -Status $statusMessage -PercentComplete $Percentage
             }
 
             if ($PSCmdlet.ShouldProcess($msg.Identity, "Release quarantined message")) {

--- a/Public/NC.Quarantine.ps1
+++ b/Public/NC.Quarantine.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Quarantine ===========================================================================================================================
+# Nebula.Core: Quarantine helpers ===================================================================================================================
 
 function Export-QuarantineEml {
     <#

--- a/Public/NC.Quarantine.ps1
+++ b/Public/NC.Quarantine.ps1
@@ -469,7 +469,8 @@ function Get-QuarantineToRelease {
             }
         }
 
-        Write-NCMessage ("Retrieved {0} quarantined items from {1:d} to {2:d}." -f $items.Count, $startDate, $endDate) -Level INFO
+        $itemLabel = if ($items.Count -eq 1) { 'item' } else { 'items' }
+        Write-NCMessage ("Retrieved {0} quarantined {1} from {2:d} to {3:d}." -f $items.Count, $itemLabel, $startDate, $endDate) -Level INFO
 
         if ($Csv.IsPresent) {
             try {
@@ -503,7 +504,8 @@ function Get-QuarantineToRelease {
 
         $selection = $items
         if ($GridView.IsPresent) {
-            $title = "{0} to {1} - {2} items" -f $startDate.Date, $endDate.Date, $items.Count
+            $itemLabel = if ($items.Count -eq 1) { 'item' } else { 'items' }
+            $title = "{0} to {1} - {2} {3}" -f $startDate.Date, $endDate.Date, $items.Count, $itemLabel
             $selection = $items | Sort-Object -Descending ReceivedTime | Out-GridView -Title $title -PassThru
             if (-not $selection) {
                 Write-NCMessage "No items selected." -Level WARNING
@@ -520,7 +522,7 @@ function Get-QuarantineToRelease {
         foreach ($item in $selection) {
             $counter++
             $Percentage = [Math]::Round(($counter / [Math]::Max($selection.Count, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($item.Subject)" -Status "$counter of $($selection.Count) ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($item.Subject)" -Status "$counter of $($selection.Count) - $Percentage%" -PercentComplete $Percentage
 
             if ($ReleaseSelected.IsPresent) {
                 if ($PSCmdlet.ShouldProcess($item.Subject, "Release quarantined message")) {

--- a/Public/NC.Security.ps1
+++ b/Public/NC.Security.ps1
@@ -59,8 +59,8 @@ function Disable-UserDevices {
 
             foreach ($upn in $queue) {
                 $counter++
-                $percent = (($counter / $queue.Count) * 100)
-                Write-Progress -Activity "Resolving user $upn" -Status "$counter of $($queue.Count) ($($percent.ToString('0.00'))%)" -PercentComplete $percent
+                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Resolving user $upn" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $resolvedUpn = Find-UserRecipient -UserPrincipalName $upn
@@ -185,8 +185,8 @@ function Disable-UserSignIn {
 
             foreach ($upn in $queue) {
                 $counter++
-                $percent = (($counter / $queue.Count) * 100)
-                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) ($($percent.ToString('0.00'))%)" -PercentComplete $percent
+                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 try {
                     $resolvedUpn = Find-UserRecipient -UserPrincipalName $upn
@@ -346,8 +346,8 @@ function Revoke-UserSessions {
 
             foreach ($user in $queue) {
                 $counter++
-                $percent = (($counter / $queue.Count) * 100)
-                Write-Progress -Activity "Revoking sessions" -Status "$counter of $($queue.Count) ($($percent.ToString('0.00'))%)" -PercentComplete $percent
+                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                Write-Progress -Activity "Revoking sessions" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
 
                 if ($exclusions.Contains($user.UserPrincipalName)) {
                     Write-NCMessage ("Skipping user {0}" -f $user.UserPrincipalName) -Level INFO

--- a/Public/NC.Security.ps1
+++ b/Public/NC.Security.ps1
@@ -60,7 +60,7 @@ function Disable-UserDevices {
             foreach ($upn in $queue) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Resolving user $upn" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Resolving user $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $resolvedUpn = Find-UserRecipient -UserPrincipalName $upn
@@ -119,7 +119,8 @@ function Disable-UserDevices {
                 $results
             }
             elseif ($results.Count -gt 0) {
-                Write-NCMessage ("Disabled {0} device(s)." -f $results.Count) -Level SUCCESS
+                $deviceLabel = if ($results.Count -eq 1) { 'device' } else { 'devices' }
+                Write-NCMessage ("Disabled {0} {1}." -f $results.Count, $deviceLabel) -Level SUCCESS
             }
         }
         finally {
@@ -186,7 +187,7 @@ function Disable-UserSignIn {
             foreach ($upn in $queue) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
                     $resolvedUpn = Find-UserRecipient -UserPrincipalName $upn
@@ -227,7 +228,8 @@ function Disable-UserSignIn {
                 $results
             }
             elseif ($results.Count -gt 0) {
-                Write-NCMessage ("Sign-in disabled for {0} user(s)." -f $results.Count) -Level SUCCESS
+                $userLabel = if ($results.Count -eq 1) { 'user' } else { 'users' }
+                Write-NCMessage ("Sign-in disabled for {0} {1}." -f $results.Count, $userLabel) -Level SUCCESS
             }
         }
         finally {
@@ -347,7 +349,7 @@ function Revoke-UserSessions {
             foreach ($user in $queue) {
                 $counter++
                 $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
-                Write-Progress -Activity "Revoking sessions" -Status "$counter of $($queue.Count) ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Revoking sessions" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 if ($exclusions.Contains($user.UserPrincipalName)) {
                     Write-NCMessage ("Skipping user {0}" -f $user.UserPrincipalName) -Level INFO
@@ -375,7 +377,8 @@ function Revoke-UserSessions {
                 $results
             }
             elseif ($results.Count -gt 0) {
-                Write-NCMessage ("Revoked sessions for {0} user(s)." -f $results.Count) -Level SUCCESS
+                $userLabel = if ($results.Count -eq 1) { 'user' } else { 'users' }
+                Write-NCMessage ("Revoked sessions for {0} {1}." -f $results.Count, $userLabel) -Level SUCCESS
             }
         }
         finally {

--- a/Public/NC.Statistics.ps1
+++ b/Public/NC.Statistics.ps1
@@ -56,7 +56,7 @@ function Export-MboxStatistics {
         }
 
         if (-not $mailboxes -or $mailboxes.Count -eq 0) {
-            Write-NCMessage "No mailboxes found matching the provided criteria." -Level WARNING
+            Write-NCMessage "No mailboxes matched the provided criteria." -Level WARNING
             return
         }
 
@@ -76,7 +76,7 @@ function Export-MboxStatistics {
         foreach ($mailbox in $mailboxes) {
             $processedCount++
             $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
+            Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
             $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
             $mailboxSizeGb = if ($stats) { Convert-MbxSizeToGB -SizeObject $stats.TotalItemSize } else { "Error" }
@@ -212,7 +212,7 @@ function Export-MboxDeletedItemSize {
             }
 
             if (-not $mailboxes -or $mailboxes.Count -eq 0) {
-                Write-NCMessage "No user mailboxes found matching the provided criteria." -Level WARNING
+                Write-NCMessage "No user mailboxes matched the provided criteria." -Level WARNING
                 return
             }
 
@@ -222,7 +222,7 @@ function Export-MboxDeletedItemSize {
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
                 $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
                 if (-not $stats) {
@@ -323,7 +323,7 @@ function Get-MboxStatistics {
             }
 
             if (-not $mailboxes -or $mailboxes.Count -eq 0) {
-                Write-NCMessage "No mailboxes found matching the provided criteria." -Level WARNING
+                Write-NCMessage "No mailboxes matched the provided criteria." -Level WARNING
                 return
             }
 
@@ -333,7 +333,7 @@ function Get-MboxStatistics {
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
                 $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
-                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
+                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
                 if (-not $stats) {

--- a/Public/NC.Statistics.ps1
+++ b/Public/NC.Statistics.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Statistics ===========================================================================================================================
+# Nebula.Core: Statistics helpers ===================================================================================================================
 
 function Export-MboxStatistics {
     <#
@@ -150,6 +150,110 @@ function Export-MboxStatistics {
     }
 }
 
+function Export-MboxDeletedItemSize {
+    <#
+    .SYNOPSIS
+        Exports mailbox deleted item store usage.
+    .DESCRIPTION
+        Ensures an Exchange Online session, retrieves all user mailboxes or a selected subset,
+        calculates the deleted item size for each mailbox, and exports the report to CSV by default.
+    .PARAMETER UserPrincipalName
+        Optional mailbox identity or identities. Accepts pipeline input.
+    .PARAMETER CsvFolder
+        Destination folder for the CSV file when exporting the report.
+    .PARAMETER Csv
+        When present, export the report to CSV. Defaults to on.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'Identity', 'Mailbox', 'SourceMailbox')]
+        [string[]]$UserPrincipalName,
+        [string]$CsvFolder,
+        [bool]$Csv = $true
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $requestedMailboxes = [System.Collections.Generic.List[string]]::new()
+        $report = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+        foreach ($entry in $UserPrincipalName) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $requestedMailboxes.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if (-not (Test-EOLConnection)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
+                return
+            }
+
+            $mailboxes = @()
+            if ($requestedMailboxes.Count -gt 0) {
+                foreach ($mailboxId in ($requestedMailboxes | Select-Object -Unique)) {
+                    try {
+                        $mailboxes += @(Get-Mailbox -Identity $mailboxId -ErrorAction Stop)
+                    }
+                    catch {
+                        Write-NCMessage "Mailbox '$mailboxId' not found. $($_.Exception.Message)" -Level WARNING
+                    }
+                }
+            }
+            else {
+                $mailboxes = @(Get-Mailbox -ResultSize Unlimited -WarningAction SilentlyContinue |
+                    Where-Object { $_.RecipientTypeDetails -eq 'UserMailbox' })
+            }
+
+            if (-not $mailboxes -or $mailboxes.Count -eq 0) {
+                Write-NCMessage "No user mailboxes found matching the provided criteria." -Level WARNING
+                return
+            }
+
+            $totalMailboxes = $mailboxes.Count
+            $processedCount = 0
+
+            foreach ($mailbox in $mailboxes) {
+                $processedCount++
+                $percentComplete = (($processedCount / $totalMailboxes) * 100)
+                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+
+                $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
+                if (-not $stats) {
+                    continue
+                }
+
+                $report.Add([pscustomobject][ordered]@{
+                        DisplayName            = $mailbox.DisplayName
+                        PrimarySmtpAddress     = $mailbox.PrimarySmtpAddress
+                        TotalDeletedItemSizeGB = Convert-MbxSizeToGB -SizeObject $stats.TotalDeletedItemSize
+                    }) | Out-Null
+            }
+
+            if ($Csv) {
+                $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
+                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DeletedItemSize.csv"
+                $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                Write-NCMessage "Deleted item size report exported to $csvPath." -Level SUCCESS
+                $csvPath
+            }
+            else {
+                $report
+            }
+        }
+        finally {
+            Write-Progress -Activity "Processing deleted item size" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
 function Get-MboxStatistics {
     <#
     .SYNOPSIS
@@ -247,7 +351,7 @@ function Get-MboxStatistics {
 
                     try {
                         $oldestItem = Get-MailboxFolderStatistics -Identity $mailbox.UserPrincipalName -IncludeOldestAndNewestItems -ErrorAction Stop |
-                            Where-Object { $_.OldestItemReceivedDate -ne $null } |
+                            Where-Object { $null -ne $_.OldestItemReceivedDate } |
                             Sort-Object -Property OldestItemReceivedDate |
                             Select-Object -First 1
 

--- a/Public/NC.Statistics.ps1
+++ b/Public/NC.Statistics.ps1
@@ -75,8 +75,8 @@ function Export-MboxStatistics {
 
         foreach ($mailbox in $mailboxes) {
             $processedCount++
-            $percentComplete = (($processedCount / $totalMailboxes) * 100)
-            Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+            $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+            Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
 
             $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
             $mailboxSizeGb = if ($stats) { Convert-MbxSizeToGB -SizeObject $stats.TotalItemSize } else { "Error" }
@@ -122,7 +122,7 @@ function Export-MboxStatistics {
                     $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
                     $csvInitialized = $true
                 }
-                Write-NCMessage "Processed $processedCount / $totalMailboxes mailboxes, flushed batch to CSV." -Level VERBOSE
+                Write-Verbose "Processed $processedCount / $totalMailboxes mailboxes, flushed batch to CSV."
                 $statsBuffer.Clear()
             }
         }
@@ -221,8 +221,8 @@ function Export-MboxDeletedItemSize {
 
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
-                $percentComplete = (($processedCount / $totalMailboxes) * 100)
-                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
                 if (-not $stats) {
@@ -332,8 +332,8 @@ function Get-MboxStatistics {
 
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
-                $percentComplete = (($processedCount / $totalMailboxes) * 100)
-                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($($percentComplete.ToString('0.00'))%)" -PercentComplete $percentComplete
+                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+                Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes ($Percentage%)" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
                 if (-not $stats) {

--- a/Public/NC.Utils.ps1
+++ b/Public/NC.Utils.ps1
@@ -41,7 +41,8 @@ function Format-MessageIDsFromClipboard {
     $output = $quoted -join ", "
 
     $output | Set-Clipboard
-    Write-NCMessage ("Copied {0} quarantine identity value(s) to clipboard:`n{1}" -f $normalized.Count, ($normalized -join "`n")) -Level INFO
+    $identityLabel = if ($normalized.Count -eq 1) { 'quarantine identity value' } else { 'quarantine identity values' }
+    Write-NCMessage ("Copied {0} {1} to clipboard:`n{2}" -f $normalized.Count, $identityLabel, ($normalized -join "`n")) -Level INFO
     Add-EmptyLine
     Write-NCMessage "Please wait for messages to be released." -Level INFO
 
@@ -90,7 +91,8 @@ function Format-SortedEmailsFromClipboard {
     $output = $quoted -join ", "
 
     $output | Set-Clipboard
-    Write-NCMessage ("Copied {0} unique e-mail address(es) to clipboard." -f $uniqueSortedEmails.Count) -Level INFO
+    $emailLabel = if ($uniqueSortedEmails.Count -eq 1) { 'unique e-mail address' } else { 'unique e-mail addresses' }
+    Write-NCMessage ("Copied {0} {1} to clipboard." -f $uniqueSortedEmails.Count, $emailLabel) -Level INFO
 
     if ($PassThru.IsPresent) { $output }
 }

--- a/Public/NC.Utils.ps1
+++ b/Public/NC.Utils.ps1
@@ -1,7 +1,7 @@
 #Requires -Version 5.0
 using namespace System.Management.Automation
 
-# Nebula.Core: Utilities ============================================================================================================================
+# Nebula.Core: Utilities helpers ====================================================================================================================
 
 function Format-MessageIDsFromClipboard {
     <#


### PR DESCRIPTION
- Change: Added `Export-IntuneAppInventory` for Intune app inventory reporting, with optional deployed-app status enrichment and CSV/JSON export.
- Change: Added `New-IntuneAppBasedGroup` to create or update Entra security groups from Intune-managed devices and installed applications, with support for an explicit full group name that aggregates all matches into one group.
- Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
- Change: Added an optional `-Domain` filter to `Export-MsolAccountSku` so exports can be limited to users in a specific domain, matching `Mail`, `UserPrincipalName`, and `ProxyAddresses`.
- Change: Added an optional `-License` filter to `Export-MsolAccountSku` so exports can target users holding a specific license while still including all of their assigned licenses in the CSV.
- Change: `Get-TenantMsolAccountSku` now supports `-IncludeSampleUsers` for the default sample size and renders sample-user output separately for better readability in `-AsTable` and `-GridView`.
- Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
- Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
- Change: `Get-UserMsolAccountSku` now shows an explicit warning when the target user exists but has no assigned licenses.
- Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.
- Fix: Quarantine workflows now benefit from the improved EXO reconnection path when WAM/MSAL broker state breaks after idle, lock, or sleep.
- Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.
- Improve: Added support for nested group matching, diagnostic output, mixed include/exclude aggregation, and console highlighting for exclusion rows in Intune group usage results.
- Improve: License user resolution now prefers Microsoft Graph identity (via shared `Find-UserRecipient -PreferGraphIdentity`) in `Add/Copy/Move/Get/Remove-UserMsolAccountSku`, with better handling of object IDs and hybrid alias lookups.