### PR TITLE
feat(groups): add Entra group management helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /nebula-core
 /nebula-todo
+.tokensave

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'Nebula.Core.psm1'
-    ModuleVersion        = '1.2.1'
+    ModuleVersion        = '1.2.2'
     GUID                 = '07acc3c0-14dc-4c1d-a1d0-6140e83c2a41'
     Author               = 'Giovanni Solone'
     Description          = 'A PowerShell module that go beyond your workstations. It will make your Microsoft 365 life easier!'
@@ -31,7 +31,6 @@
         'Export-EmptyEntraGroups',
         'Export-IntuneAppInventory',
         'Export-M365Group',
-        'Export-MboxAlias',
         'Export-MboxDeletedItemSize',
         'Export-MboxPermission',
         'Export-MboxStatistics',
@@ -126,22 +125,13 @@
             )
             ProjectUri   = 'https://github.com/gioxx/Nebula.Core'
             LicenseUri   = 'https://opensource.org/licenses/MIT'
-            IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/Assets/icon.png'
+            IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/icon.png'
             ReleaseNotes = @'
-- Change: Added `Export-IntuneAppInventory` for Intune app inventory reporting, with optional deployed-app status enrichment and CSV/JSON export.
-- Change: Added `New-IntuneAppBasedGroup` to create or update Entra security groups from Intune-managed devices and installed applications, with support for an explicit full group name that aggregates all matches into one group.
-- Change: Added `Search-IntuneProfileLocation` to locate which Intune Graph surface hosts a profile and return its source, ID, and OData type.
-- Change: Added an optional `-Domain` filter to `Export-MsolAccountSku` so exports can be limited to users in a specific domain, matching `Mail`, `UserPrincipalName`, and `ProxyAddresses`.
-- Change: Added an optional `-License` filter to `Export-MsolAccountSku` so exports can target users holding a specific license while still including all of their assigned licenses in the CSV.
-- Change: `Get-TenantMsolAccountSku` now supports `-IncludeSampleUsers` for the default sample size and renders sample-user output separately for better readability in `-AsTable` and `-GridView`.
-- Change: Added resilient Exchange Online connection handling in `Connect-EOL`, including optional `-DisableWAM`, `-Device`, `-NoWamFallback`, and automatic retry without WAM after broker-related sign-in failures.
-- Change: Refactored Intune group usage logic into dedicated private helpers to keep `NC.Intune.ps1` focused on public cmdlets.
-- Change: `Get-UserMsolAccountSku` now shows an explicit warning when the target user exists but has no assigned licenses.
-- Fix: `Get-UserMsolAccountSku -Clipboard` no longer claims success when user lookup or license retrieval fails; it now warns when there is no license data to copy.
-- Fix: Quarantine workflows now benefit from the improved EXO reconnection path when WAM/MSAL broker state breaks after idle, lock, or sleep.
-- Fix: Reworked `Get-IntuneProfileAssignmentsByGroup` to correctly report Entra group usage across Intune device configurations, settings catalog policies, and app assignments.
-- Improve: Added support for nested group matching, diagnostic output, mixed include/exclude aggregation, and console highlighting for exclusion rows in Intune group usage results.
-- Improve: License user resolution now prefers Microsoft Graph identity (via shared `Find-UserRecipient -PreferGraphIdentity`) in `Add/Copy/Move/Get/Remove-UserMsolAccountSku`, with better handling of object IDs and hybrid alias lookups.
+- Improve: `Get-TenantMsolAccountSku` now supports optional `-Domain` filtering for sample users, so license sample output can be scoped to a specific mail domain.
+- Change: Removed `Export-MboxAlias`. Use `Get-MboxAlias` for single mailbox queries and CSV reports, including positional single-mailbox input.
+- Fix: Consolidated alias export behavior under `Get-MboxAlias` and fixed CSV filtering so primary-only recipients are excluded after MOERA filtering.
+- Improve: `Get-MboxAlias` can now include DisplayName and Name in CSV exports, optionally include primary-only recipients with `-IncludePrimaryOnly`, and opt into MOERA rows with `-IncludeMoera`.
+- Improve: CSV export cmdlets in Calendar, Groups, Licenses and Statistics now consistently finish with a success message that includes the generated CSV path instead of echoing the path as a second pipeline line.
 '@
         }
     }

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -14,17 +14,21 @@
     )
     FunctionsToExport    = @(
         'Add-EntraGroupDevice',
+        'Add-EntraGroupOwner',
         'Add-EntraGroupUser',
         'Add-MboxAlias',
         'Add-MboxPermission',
         'Add-UserMsolAccountSku',
         'Connect-EOL',
         'Connect-Nebula',
+        'Copy-EntraGroup',
+        'Copy-EntraGroupOwner',
         'Copy-OoOMessage',
         'Copy-UserMsolAccountSku',
         'Disable-UserDevices',
         'Disable-UserSignIn',
         'Disconnect-Nebula',
+        'Edit-ContentFilterPolicy',
         'Export-CalendarPermission',
         'Export-DistributionGroups',
         'Export-DynamicDistributionGroups',
@@ -39,14 +43,15 @@
         'Format-MessageIDsFromClipboard',
         'Format-QuotedListFromClipboard',
         'Format-SortedEmailsFromClipboard',
+        'Get-ContentFilterPolicy',
         'Get-DynamicDistributionGroupFilter',
         'Get-EntraGroupDevice',
         'Get-EntraGroupMembers',
         'Get-EntraGroupUser',
         'Get-IntuneProfileAssignmentsByGroup',
-        'Get-ContentFilterPolicy',
         'Get-MboxAlias',
         'Get-MboxLastMessageTrace',
+        'Get-MboxMrmCleanup',
         'Get-MboxPermission',
         'Get-MboxPrimarySmtpAddress',
         'Get-MboxStatistics',
@@ -61,27 +66,31 @@
         'Get-TenantMsolAccountSku',
         'Get-UserGroups',
         'Get-UserLastSeen',
-        'Get-UserUsageLocation',
         'Get-UserMsolAccountSku',
+        'Get-UserUsageLocation',
         'Move-UserMsolAccountSku',
-        'New-SharedMailbox',
+        'New-EntraSecurityGroup',
         'New-IntuneAppBasedGroup',
+        'New-SharedMailbox',
         'Remove-EntraGroupDevice',
+        'Remove-EntraGroupOwner',
         'Remove-EntraGroupUser',
         'Remove-MboxAlias',
+        'Remove-MboxMrmCleanup',
         'Remove-MboxPermission',
         'Remove-UserMsolAccountSku',
         'Revoke-UserSessions',
-        'Edit-ContentFilterPolicy',
         'Search-EntraGroup',
         'Search-IntuneProfileLocation',
         'Search-MboxCutoffWindow',
+        'Set-EntraGroupDescription',
+        'Set-EntraGroupDisplayName',
         'Set-MboxLanguage',
         'Set-MboxMrmCleanup',
         'Set-MboxRulesQuota',
-        'Set-UserUsageLocation',
         'Set-OoO',
         'Set-SharedMboxCopyForSent',
+        'Set-UserUsageLocation',
         'Sync-NebulaConfig',
         'Test-SharedMailboxCompliance',
         'Unlock-QuarantineFrom',
@@ -132,14 +141,20 @@
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/icon.png'
         ReleaseNotes = @'
-- Add: `Get-ContentFilterPolicy` to list hosted content filter policies and inspect their current allow/block lists before editing.
+- Add: `Add/Remove/Copy-EntraGroupOwner` plus `Copy-EntraGroup` and `New-EntraSecurityGroup` to create, clone, and manage Entra security groups with the same workflow style used for licenses.
 - Add: `Edit-ContentFilterPolicy` to manage hosted content filter allow/block lists, allowed-sender contacts, and matching transport-rule domain exceptions from a single cmdlet.
 - Add: `Format-QuotedListFromClipboard` to convert clipboard text from Excel-style columns or similar lists into a quoted, comma-separated value list.
+- Add: `Get-ContentFilterPolicy` to list hosted content filter policies and inspect their current allow/block lists before editing.
+- Add: `Get-MboxMrmCleanup` to inventory retention tags, policies, and mailbox assignments for one-shot MRM cleanup workflows.
 - Add: `Get-UserUsageLocation` to read current Microsoft Graph `UsageLocation` values and compare them with the configured default.
+- Add: `Remove-MboxMrmCleanup` to restore mailboxes back to a standard retention policy or default before deleting temporary MRM cleanup objects.
+- Add: `Set-EntraGroupDescription` to update an Entra group description without recreating the group.
+- Add: `Set-EntraGroupDisplayName` to rename an Entra group without recreating it.
 - Add: `Set-UserUsageLocation` to update Microsoft Graph `UsageLocation` values from the pipeline, using the configured default when `-UsageLocation` is omitted.
 - Change: Removed `Export-MboxAlias`. Use `Get-MboxAlias` for single mailbox queries and CSV reports, including positional single-mailbox input.
 - Fix: `Export-CalendarPermission` now handles deserialized Exchange permission objects correctly when resuming or deduplicating CSV rows.
 - Fix: Consolidated alias export behavior under `Get-MboxAlias` and fixed CSV filtering so primary-only recipients are excluded after MOERA filtering.
+- Improve: `Add-EntraGroupUser` now detects groups synchronized from on-premises AD and reports a clearer error when membership cannot be changed directly in Entra.
 - Improve: `Export-CalendarPermission` now supports batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated mailbox failures.
 - Improve: `Export-DistributionGroups`, `Export-DynamicDistributionGroups`, and `Export-M365Group` now support batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated group-member retrieval failures.
 - Improve: `Export-IntuneAppInventory` now supports batch-flushed CSV export with optional resume from the latest CSV or a specific `-CsvPath`, plus a `-MaxConsecutiveErrors` guard for repeated device-level failures.

--- a/Nebula.Core.psd1
+++ b/Nebula.Core.psd1
@@ -37,12 +37,14 @@
         'Export-MsolAccountSku',
         'Export-QuarantineEml',
         'Format-MessageIDsFromClipboard',
+        'Format-QuotedListFromClipboard',
         'Format-SortedEmailsFromClipboard',
         'Get-DynamicDistributionGroupFilter',
         'Get-EntraGroupDevice',
         'Get-EntraGroupMembers',
         'Get-EntraGroupUser',
         'Get-IntuneProfileAssignmentsByGroup',
+        'Get-ContentFilterPolicy',
         'Get-MboxAlias',
         'Get-MboxLastMessageTrace',
         'Get-MboxPermission',
@@ -59,6 +61,7 @@
         'Get-TenantMsolAccountSku',
         'Get-UserGroups',
         'Get-UserLastSeen',
+        'Get-UserUsageLocation',
         'Get-UserMsolAccountSku',
         'Move-UserMsolAccountSku',
         'New-SharedMailbox',
@@ -69,12 +72,14 @@
         'Remove-MboxPermission',
         'Remove-UserMsolAccountSku',
         'Revoke-UserSessions',
+        'Edit-ContentFilterPolicy',
         'Search-EntraGroup',
         'Search-IntuneProfileLocation',
         'Search-MboxCutoffWindow',
         'Set-MboxLanguage',
         'Set-MboxMrmCleanup',
         'Set-MboxRulesQuota',
+        'Set-UserUsageLocation',
         'Set-OoO',
         'Set-SharedMboxCopyForSent',
         'Sync-NebulaConfig',
@@ -126,11 +131,25 @@
             ProjectUri   = 'https://github.com/gioxx/Nebula.Core'
             LicenseUri   = 'https://opensource.org/licenses/MIT'
             IconUri      = 'https://raw.githubusercontent.com/gioxx/Nebula.Core/main/icon.png'
-            ReleaseNotes = @'
-- Improve: `Get-TenantMsolAccountSku` now supports optional `-Domain` filtering for sample users, so license sample output can be scoped to a specific mail domain.
+        ReleaseNotes = @'
+- Add: `Get-ContentFilterPolicy` to list hosted content filter policies and inspect their current allow/block lists before editing.
+- Add: `Edit-ContentFilterPolicy` to manage hosted content filter allow/block lists, allowed-sender contacts, and matching transport-rule domain exceptions from a single cmdlet.
+- Add: `Format-QuotedListFromClipboard` to convert clipboard text from Excel-style columns or similar lists into a quoted, comma-separated value list.
+- Add: `Get-UserUsageLocation` to read current Microsoft Graph `UsageLocation` values and compare them with the configured default.
+- Add: `Set-UserUsageLocation` to update Microsoft Graph `UsageLocation` values from the pipeline, using the configured default when `-UsageLocation` is omitted.
 - Change: Removed `Export-MboxAlias`. Use `Get-MboxAlias` for single mailbox queries and CSV reports, including positional single-mailbox input.
+- Fix: `Export-CalendarPermission` now handles deserialized Exchange permission objects correctly when resuming or deduplicating CSV rows.
 - Fix: Consolidated alias export behavior under `Get-MboxAlias` and fixed CSV filtering so primary-only recipients are excluded after MOERA filtering.
+- Improve: `Export-CalendarPermission` now supports batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated mailbox failures.
+- Improve: `Export-DistributionGroups`, `Export-DynamicDistributionGroups`, and `Export-M365Group` now support batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated group-member retrieval failures.
+- Improve: `Export-IntuneAppInventory` now supports batch-flushed CSV export with optional resume from the latest CSV or a specific `-CsvPath`, plus a `-MaxConsecutiveErrors` guard for repeated device-level failures.
+- Improve: `Export-MboxPermission` now supports batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated mailbox-level failures.
+- Improve: `Export-MboxStatistics` now supports batch flushing with visible progress, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated mailbox failures.
+- Improve: `Export-MsolAccountSku` and `Export-MboxDeletedItemSize` now support batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a consecutive-error stop guard.
 - Improve: `Get-MboxAlias` can now include DisplayName and Name in CSV exports, optionally include primary-only recipients with `-IncludePrimaryOnly`, and opt into MOERA rows with `-IncludeMoera`.
+- Improve: `Get-MboxAlias` now also supports batch flushing, optional resume from the latest CSV or a specific `-CsvPath`, and a `-MaxConsecutiveErrors` guard for repeated recipient failures.
+- Improve: `Get-MboxStatistics` now exposes `ArchiveQuotaGB` alongside archive size and usage percentage so archive utilization is easier to interpret.
+- Improve: `Get-TenantMsolAccountSku` now supports optional `-Domain` filtering for sample users, so license sample output can be scoped to a specific mail domain.
 - Improve: CSV export cmdlets in Calendar, Groups, Licenses and Statistics now consistently finish with a success message that includes the generated CSV path instead of echoing the path as a second pipeline line.
 '@
         }

--- a/Private/NC-Hlp.Groups.ps1
+++ b/Private/NC-Hlp.Groups.ps1
@@ -1,0 +1,128 @@
+#Requires -Version 5.0
+using namespace System.Management.Automation
+
+# Nebula.Core: (Private) Group helpers ==============================================================================================================
+
+function Get-NCGraphObjectLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $props = $InputObject.PSObject.Properties
+    if ($props['userPrincipalName'] -and $InputObject.userPrincipalName) { return [string]$InputObject.userPrincipalName }
+    if ($props['displayName'] -and $InputObject.displayName) { return [string]$InputObject.displayName }
+    if ($props['appDisplayName'] -and $InputObject.appDisplayName) { return [string]$InputObject.appDisplayName }
+    if ($props['id'] -and $InputObject.id) { return [string]$InputObject.id }
+    return [string]$InputObject
+}
+
+function Resolve-NCEntraGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$GroupName,
+
+        [string]$GroupId
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($GroupId)) {
+        try {
+            return Get-MgGroup -GroupId $GroupId -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Entra group with ID '$GroupId' not found: $($_.Exception.Message)" -Level ERROR
+            return
+        }
+    }
+
+    $escapedName = $GroupName.Replace("'", "''")
+    try {
+        $resolvedGroup = Get-MgGroup -Filter "displayName eq '$escapedName'" -All -ErrorAction Stop | Select-Object -First 1
+    }
+    catch {
+        Write-NCMessage "Unable to resolve group '$GroupName': $($_.Exception.Message)" -Level ERROR
+        return
+    }
+
+    if (-not $resolvedGroup) {
+        try {
+            $resolvedGroup = Get-MgGroup -GroupId $GroupName -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Entra group '$GroupName' not found by name or ID" -Level ERROR
+            return
+        }
+    }
+
+    return $resolvedGroup
+}
+
+function Resolve-NCEntraOwner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OwnerIdentifier,
+
+        [switch]$TreatInputAsId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($OwnerIdentifier)) {
+        return
+    }
+
+    $owner = $null
+    $trimmed = $OwnerIdentifier.Trim()
+    $looksLikeGuid = $trimmed -match '^[0-9a-fA-F-]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+
+    if ($TreatInputAsId.IsPresent -or $looksLikeGuid) {
+        try {
+            $owner = Get-MgUser -UserId $trimmed -Property Id,UserPrincipalName,DisplayName -ErrorAction Stop
+        }
+        catch {
+            $owner = [pscustomobject]@{
+                Id = $trimmed
+                UserPrincipalName = $null
+                DisplayName = $trimmed
+            }
+        }
+    }
+    else {
+        try {
+            $owner = Get-MgUser -UserId $trimmed -Property Id,UserPrincipalName,DisplayName -ErrorAction Stop
+        }
+        catch {
+            $resolvedIdentifier = Find-UserRecipient -UserPrincipalName $trimmed -PreferGraphIdentity
+            if ($resolvedIdentifier) {
+                try {
+                    $owner = Get-MgUser -UserId $resolvedIdentifier -Property Id,UserPrincipalName,DisplayName -ErrorAction Stop
+                }
+                catch {
+                    Write-NCMessage "Unable to resolve owner '$OwnerIdentifier': $($_.Exception.Message)" -Level ERROR
+                    return
+                }
+            }
+            else {
+                Write-NCMessage "Owner '$OwnerIdentifier' not found." -Level WARNING
+                return
+            }
+        }
+    }
+
+    if (-not $owner) {
+        Write-NCMessage "Unable to determine object ID for owner '$OwnerIdentifier'." -Level ERROR
+        return
+    }
+
+    $ownerLabel = if ($owner.UserPrincipalName) { $owner.UserPrincipalName } elseif ($owner.DisplayName) { $owner.DisplayName } else { $owner.Id }
+
+    return [pscustomobject]@{
+        Id    = [string]$owner.Id
+        Label = [string]$ownerLabel
+    }
+}

--- a/Private/NC-Hlp.ModuleUtils.ps1
+++ b/Private/NC-Hlp.ModuleUtils.ps1
@@ -172,6 +172,30 @@ function Set-ProgressAndInfoPreferences {
     Set-Variable -Name ProgressPreference -Value Continue -Scope Global
 }
 
+function Get-NCProgressPercent {
+    <#
+    .SYNOPSIS
+        Calculates a percentage for progress reporting.
+    .DESCRIPTION
+        Returns a rounded percentage for the current work item against a total.
+        The total is clamped to at least 1 to avoid divide-by-zero errors.
+    .PARAMETER Current
+        Current work item count.
+    .PARAMETER Total
+        Total number of work items.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [double]$Current,
+        [Parameter(Mandatory)]
+        [double]$Total
+    )
+
+    $safeTotal = [Math]::Max($Total, 1)
+    return [Math]::Round(($Current / $safeTotal) * 100, 2)
+}
+
 function Show-Table {
     <#
     .SYNOPSIS

--- a/Private/NC-Hlp.ModuleUtils.ps1
+++ b/Private/NC-Hlp.ModuleUtils.ps1
@@ -33,6 +33,72 @@ function Format-OutputString {
     return $Value.Substring(0, $length - 3) + '...'
 }
 
+function Get-NormalizedText {
+    <#
+    .SYNOPSIS
+        Returns a lower-cased, trimmed string from a value or object.
+    .DESCRIPTION
+        Accepts plain strings, deserialized Exchange objects, and other objects with useful identity
+        properties. Falls back to the object's string representation and returns $null for blank values.
+    .PARAMETER Value
+        Value to normalize.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$Value
+    )
+
+    $text = $null
+
+    if ($Value -is [string]) {
+        $text = $Value
+    }
+    elseif ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        $items = foreach ($item in $Value) {
+            if (-not [string]::IsNullOrWhiteSpace([string]$item)) {
+                [string]$item
+            }
+        }
+
+        if ($items) {
+            $text = $items -join ', '
+        }
+    }
+    else {
+        foreach ($propertyName in @(
+            'PrimarySmtpAddress',
+            'UserPrincipalName',
+            'WindowsEmailAddress',
+            'SmtpAddress',
+            'EmailAddress',
+            'Value',
+            'Name',
+            'DisplayName',
+            'Identity',
+            'RawIdentity'
+        )) {
+            if ($Value.PSObject.Properties.Match($propertyName).Count -gt 0) {
+                $candidate = $Value.$propertyName
+                if (-not [string]::IsNullOrWhiteSpace([string]$candidate)) {
+                    $text = [string]$candidate
+                    break
+                }
+            }
+        }
+    }
+
+    if (-not $text) {
+        $text = [string]$Value
+    }
+
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
+
+    return $text.Trim().ToLowerInvariant()
+}
+
 function Invoke-NCRetry {
     <#
     .SYNOPSIS

--- a/Private/NC-Hlp.Security.ps1
+++ b/Private/NC-Hlp.Security.ps1
@@ -1,0 +1,56 @@
+#Requires -Version 5.0
+using namespace System.Management.Automation
+
+# Nebula.Core: (Private) Security helpers ===========================================================================================================
+
+function Get-NCContentFilterPolicyValues {
+    <#
+    .SYNOPSIS
+        Normalizes content filter policy list values.
+    .DESCRIPTION
+        Extracts sender or domain values from hosted content filter policy properties and returns
+        a sorted, unique string array. Used internally by the Security cmdlets.
+    .PARAMETER PolicyObject
+        Hosted content filter policy object.
+    .PARAMETER PropertyName
+        Property that contains the list to normalize.
+    .PARAMETER PreferredValueProperty
+        Preferred field name to read from each item (for example Sender or Domain).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object]$PolicyObject,
+        [Parameter(Mandatory)]
+        [string]$PropertyName,
+        [string]$PreferredValueProperty
+    )
+
+    $result = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($item in @($PolicyObject.$PropertyName)) {
+        if ($null -eq $item) {
+            continue
+        }
+
+        $value = $null
+        if ($PreferredValueProperty -and $item.PSObject.Properties.Match($PreferredValueProperty).Count -gt 0) {
+            $value = [string]$item.$PreferredValueProperty
+        }
+        elseif ($item.PSObject.Properties.Match('Sender').Count -gt 0) {
+            $value = [string]$item.Sender
+        }
+        elseif ($item.PSObject.Properties.Match('Domain').Count -gt 0) {
+            $value = [string]$item.Domain
+        }
+        else {
+            $value = [string]$item
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($value)) {
+            $result.Add($value.Trim()) | Out-Null
+        }
+    }
+
+    @($result | Sort-Object -Unique)
+}

--- a/Public/NC.Calendar.ps1
+++ b/Public/NC.Calendar.ps1
@@ -222,7 +222,7 @@ function Export-CalendarPermission {
 
             foreach ($mailbox in $targets) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($targets.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $targets.Count
                 Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($targets.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -283,9 +283,6 @@ function Export-CalendarPermission {
 
             if ($PassThru.IsPresent) {
                 $results
-            }
-            else {
-                $csvPath
             }
         }
         finally {
@@ -359,7 +356,7 @@ function Get-RoomDetails {
             $counter = 0
             foreach ($group in $roomGroups) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($roomGroups.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $roomGroups.Count
                 Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $($roomGroups.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -636,3 +633,5 @@ function Set-OoO {
 
     end { Restore-ProgressAndInfoPreferences }
 }
+
+

--- a/Public/NC.Calendar.ps1
+++ b/Public/NC.Calendar.ps1
@@ -119,6 +119,14 @@ function Export-CalendarPermission {
         Scan every mailbox in the tenant (excluding GuestMailUser). Implies CSV export.
     .PARAMETER PassThru
         Emit the collected permission objects in addition to writing the CSV report.
+    .PARAMETER BatchSize
+        Number of processed mailboxes before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive mailbox-level failures.
     .EXAMPLE
         Export-CalendarPermission -SourceMailbox user@contoso.com -OutputFolder C:\Temp
     .EXAMPLE
@@ -132,13 +140,23 @@ function Export-CalendarPermission {
         [string[]]$SourceDomain,
         [string]$OutputFolder,
         [switch]$All,
-        [switch]$PassThru
+        [switch]$PassThru,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     begin {
         Set-ProgressAndInfoPreferences
         $mailboxInputs = [System.Collections.Generic.List[string]]::new()
         $domainInputs = [System.Collections.Generic.List[string]]::new()
+        $results = [System.Collections.Generic.List[object]]::new()
+        $processedSinceFlush = 0
+        $consecutiveErrors = 0
+        $aborted = $false
     }
 
     process {
@@ -217,6 +235,69 @@ function Export-CalendarPermission {
                 return
             }
 
+            $normalizeText = {
+                param($value)
+                return Get-NormalizedText -Value $value
+            }
+            $buildPermissionKey = {
+                param($row)
+
+                $mailboxId = & $normalizeText $row.MailboxIdentity
+                if (-not $mailboxId) {
+                    $mailboxId = & $normalizeText $row.PrimarySmtpAddress
+                }
+                $user = & $normalizeText $row.User
+                $permissions = & $normalizeText $row.Permissions
+                return "{0}|{1}|{2}" -f $mailboxId, $user, $permissions
+            }
+            $existingPermissionKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $csvPathResolved = $null
+            $folderForExport = $reportFolder
+
+            $defaultCsvPath = New-File (Join-Path -Path $folderForExport -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-CalendarPermissions-Report.csv")
+            $csvPathResolved = $defaultCsvPath
+
+            if ($Resume) {
+                $resumePath = $null
+                if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                    $resumePath = $CsvPath
+                }
+                else {
+                    $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-CalendarPermissions-Report.csv" |
+                        Sort-Object LastWriteTime -Descending |
+                        Select-Object -First 1
+                    if ($existingCsv) {
+                        $resumePath = $existingCsv.FullName
+                    }
+                }
+
+                if ($resumePath) {
+                    $csvPathResolved = $resumePath
+                    if (Test-Path -LiteralPath $csvPathResolved) {
+                        try {
+                            foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                $null = $existingPermissionKeys.Add((& $buildPermissionKey $row))
+                            }
+                            Write-NCMessage ("Resuming calendar permission export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingPermissionKeys.Count) -Level INFO
+                        }
+                        catch {
+                            Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                            $existingPermissionKeys.Clear()
+                            $csvPathResolved = $defaultCsvPath
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                    }
+                }
+                else {
+                    Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+                }
+            }
+
+            Write-NCMessage ("Calendar permission export will flush every {0} mailbox(es). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+            Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+
             $results = [System.Collections.Generic.List[object]]::new()
             $counter = 0
 
@@ -230,6 +311,11 @@ function Export-CalendarPermission {
                 }
                 catch {
                     Write-NCMessage "Unable to load mailbox '$($mailbox.Identity)'. $($_.Exception.Message)" -Level ERROR
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
@@ -238,6 +324,11 @@ function Export-CalendarPermission {
                 }
                 catch {
                     Write-NCMessage "Unable to read calendar folder for '$($exoMailbox.PrimarySmtpAddress)'. $($_.Exception.Message)" -Level ERROR
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
@@ -254,27 +345,72 @@ function Export-CalendarPermission {
                 }
                 catch {
                     Write-NCMessage "Unable to retrieve calendar permissions for '$($exoMailbox.PrimarySmtpAddress)'. $($_.Exception.Message)" -Level ERROR
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
                 foreach ($perm in $folderPerms) {
-                    $results.Add([pscustomobject]@{
-                            PrimarySmtpAddress = $exoMailbox.PrimarySmtpAddress
-                            User               = $perm.User
-                            Permissions        = ($perm.AccessRights -join ', ')
-                        }) | Out-Null
+                    $row = [pscustomobject]@{
+                        MailboxIdentity     = $exoMailbox.Identity
+                        PrimarySmtpAddress  = $exoMailbox.PrimarySmtpAddress
+                        User                = $perm.User
+                        Permissions         = ($perm.AccessRights -join ', ')
+                    }
+                    $rowKey = & $buildPermissionKey $row
+                    if ($Resume -and $existingPermissionKeys.Contains($rowKey)) {
+                        continue
+                    }
+                    $results.Add($row) | Out-Null
+                }
+
+                $consecutiveErrors = 0
+                $processedSinceFlush++
+                if ($BatchSize -gt 0 -and $results.Count -gt 0 -and ($processedSinceFlush -ge $BatchSize)) {
+                    if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                        $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                    }
+                    else {
+                        $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                    }
+                    $results.Clear()
+                    $processedSinceFlush = 0
                 }
             }
 
-            if ($results.Count -eq 0) {
+            if ($aborted -and $results.Count -gt 0) {
+                if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                }
+                else {
+                    $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                }
+                $results.Clear()
+            }
+
+            if ($results.Count -eq 0 -and (-not (Test-Path -LiteralPath $csvPathResolved) -or (Get-Item -LiteralPath $csvPathResolved).Length -eq 0)) {
                 Write-NCMessage "No calendar permissions found for the selected scope." -Level WARNING
                 return
             }
 
-            $csvPath = New-File (Join-Path -Path $reportFolder -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-CalendarPermissions-Report.csv")
             try {
-                $results | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-                Write-NCMessage ("Calendar permission report exported to {0}" -f $csvPath) -Level SUCCESS
+                if ($results.Count -gt 0) {
+                    if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                        $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                    }
+                    else {
+                        $results | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                    }
+                }
+                if ($aborted) {
+                    Write-NCMessage ("Calendar permission export stopped early. Partial data kept at {0}" -f $csvPathResolved) -Level ERROR
+                }
+                else {
+                    Write-NCMessage ("Calendar permission report exported to {0}" -f $csvPathResolved) -Level SUCCESS
+                }
             }
             catch {
                 Write-NCMessage "Unable to write CSV report. $($_.Exception.Message)" -Level ERROR

--- a/Public/NC.Compliance.ps1
+++ b/Public/NC.Compliance.ps1
@@ -3,6 +3,506 @@ using namespace System.Management.Automation
 
 # Nebula.Core: Compliance helpers ===================================================================================================================
 
+function Get-MboxMrmCleanup {
+    <#
+    .SYNOPSIS
+        Lists retention tags, policies, and mailbox assignments for MRM cleanup workflows.
+    .DESCRIPTION
+        Connects to Exchange Online and inventories retention policies. The output defaults to the temporary
+        Nebula.Core cleanup objects created by Set-MboxMrmCleanup. Use -AllTenantObjects to list every
+        retention policy in the tenant. Each row includes the linked tag details inline and the mailbox count,
+        so you can spot temporary cleanup objects and decide what can be removed safely.
+    .PARAMETER Identity
+        Retention policy name or linked tag name to inspect. When omitted, temporary cleanup policies are returned.
+    .PARAMETER AllTenantObjects
+        Include every retention policy in the tenant instead of limiting the inventory to temporary Nebula.Core
+        cleanup objects.
+    .PARAMETER Detailed
+        Include the linked tag names and mailbox lists in the output.
+    .EXAMPLE
+        Get-MboxMrmCleanup
+    .EXAMPLE
+        Get-MboxMrmCleanup -Detailed
+    .EXAMPLE
+        Get-MboxMrmCleanup -AllTenantObjects
+    .EXAMPLE
+        Get-MboxMrmCleanup -Identity OneShot_PreCutoff_20250101
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Name', 'TagName', 'PolicyName')]
+        [string[]]$Identity,
+        [switch]$AllTenantObjects,
+        [switch]$Detailed
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $Identity) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if (-not (Test-EOLConnection)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
+                return
+            }
+
+            $tagObjects = @()
+            $policyObjects = @()
+
+            try {
+                $tagObjects = @(Get-RetentionPolicyTag -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve retention policy tags. $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            try {
+                $policyObjects = @(Get-RetentionPolicy -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve retention policies. $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            $mailboxObjects = @()
+            try {
+                if (Get-Command -Name Get-EXOMailbox -ErrorAction SilentlyContinue) {
+                    $mailboxObjects = @(Get-EXOMailbox -ResultSize Unlimited -Properties RetentionPolicy, RecipientTypeDetails, DisplayName, PrimarySmtpAddress -ErrorAction Stop)
+                }
+                else {
+                    $mailboxObjects = @(Get-Mailbox -ResultSize Unlimited -WarningAction SilentlyContinue -ErrorAction Stop)
+                }
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve mailbox assignments for retention policies. $($_.Exception.Message)" -Level WARNING
+                $mailboxObjects = @()
+            }
+
+            $mailboxesByPolicy = [System.Collections.Generic.Dictionary[string, System.Collections.Generic.List[object]]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($mailbox in $mailboxObjects) {
+                $retentionPolicyName = [string]$mailbox.RetentionPolicy
+                if ([string]::IsNullOrWhiteSpace($retentionPolicyName)) {
+                    continue
+                }
+
+                if (-not $mailboxesByPolicy.ContainsKey($retentionPolicyName)) {
+                    $mailboxesByPolicy[$retentionPolicyName] = [System.Collections.Generic.List[object]]::new()
+                }
+
+                $mailboxesByPolicy[$retentionPolicyName].Add($mailbox) | Out-Null
+            }
+
+            $policyLinksByTag = [System.Collections.Generic.Dictionary[string, System.Collections.Generic.List[string]]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($policy in $policyObjects) {
+                foreach ($tagLink in @($policy.RetentionPolicyTagLinks)) {
+                    if ([string]::IsNullOrWhiteSpace([string]$tagLink)) {
+                        continue
+                    }
+
+                    $tagName = [string]$tagLink
+                    if (-not $policyLinksByTag.ContainsKey($tagName)) {
+                        $policyLinksByTag[$tagName] = [System.Collections.Generic.List[string]]::new()
+                    }
+
+                    $policyLinksByTag[$tagName].Add([string]$policy.Name) | Out-Null
+                }
+            }
+
+            $policyResults = foreach ($policy in $policyObjects) {
+                if ($null -eq $policy) {
+                    continue
+                }
+
+                $policyName = [string]$policy.Name
+                $linkedTags = @($policy.RetentionPolicyTagLinks | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                $primaryTagName = $linkedTags | Select-Object -First 1
+                $primaryTag = $null
+                if (-not [string]::IsNullOrWhiteSpace($primaryTagName)) {
+                    $primaryTag = $tagObjects | Where-Object { [string]$_.Name -ieq $primaryTagName } | Select-Object -First 1
+                }
+
+                if (-not $AllTenantObjects.IsPresent -and $policyName -notlike 'OneShot_PreCutoff_*') {
+                    continue
+                }
+
+                if ($targets.Count -gt 0) {
+                    $matchesPolicy = $targets -contains $policyName
+                    $matchesLinkedTag = $false
+                    foreach ($tagName in $linkedTags) {
+                        if ($targets -contains $tagName) {
+                            $matchesLinkedTag = $true
+                            break
+                        }
+                    }
+
+                    if (-not $matchesPolicy -and -not $matchesLinkedTag) {
+                        continue
+                    }
+                }
+
+                $assignedMailboxes = @()
+                if ($mailboxesByPolicy.ContainsKey($policyName)) {
+                    $assignedMailboxes = @($mailboxesByPolicy[$policyName] | ForEach-Object {
+                            if ($_.PrimarySmtpAddress) { [string]$_.PrimarySmtpAddress }
+                            elseif ($_.UserPrincipalName) { [string]$_.UserPrincipalName }
+                            else { [string]$_.Identity }
+                        } | Sort-Object -Unique)
+                }
+
+                $ageLimitDays = if ($primaryTag -and ($primaryTag.AgeLimitForRetention -is [TimeSpan])) {
+                    [int][math]::Floor($primaryTag.AgeLimitForRetention.TotalDays)
+                }
+                elseif ($primaryTag) {
+                    $primaryTag.AgeLimitForRetention
+                }
+                else {
+                    $null
+                }
+
+                $row = [ordered]@{
+                    ObjectType           = 'Policy'
+                    Identity             = $policy.Identity
+                    Name                 = $policyName
+                    LinkedTagName        = $primaryTagName
+                    TagType              = $primaryTag.Type
+                    RetentionEnabled     = $primaryTag.RetentionEnabled
+                    AgeLimitForRetentionDays = $ageLimitDays
+                    RetentionAction      = $primaryTag.RetentionAction
+                    ConditionSummary     = if ($primaryTag) {
+                        "Type={0}; AgeLimit={1}d; Action={2}; Enabled={3}" -f $primaryTag.Type, $ageLimitDays, $primaryTag.RetentionAction, $primaryTag.RetentionEnabled
+                    }
+                    elseif ($linkedTags.Count -gt 0) {
+                        "TagLinks={0}" -f ($linkedTags -join ', ')
+                    }
+                    else {
+                        'TagLinks='
+                    }
+                    LinkedTagCount       = $linkedTags.Count
+                    TagLinkCount         = $linkedTags.Count
+                    AssignedMailboxCount = $assignedMailboxes.Count
+                }
+
+                if ($Detailed.IsPresent) {
+                    $row.LinkedTagNames = $linkedTags
+                    $row.AssignedMailboxes = $assignedMailboxes
+                }
+
+                [pscustomobject]$row
+            }
+
+            $results = @($policyResults)
+            if ($results.Count -eq 0) {
+                Write-NCMessage "No retention policies matched the requested filters." -Level WARNING
+                return
+            }
+
+            $results | Sort-Object ObjectType, Name
+        }
+        finally {
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
+function Remove-MboxMrmCleanup {
+    <#
+    .SYNOPSIS
+        Removes temporary MRM cleanup tags and policies.
+    .DESCRIPTION
+        Finds the specified retention policy tag and policy, moves the affected mailboxes back to the
+        default retention policy or to a specific standard policy, and then removes the temporary policy
+        and tag when they are no longer needed.
+    .PARAMETER Identity
+        Retention tag or retention policy name to remove. When omitted, all Nebula.Core temporary cleanup
+        objects (names starting with OneShot_PreCutoff_) are targeted.
+    .PARAMETER Mailbox
+        Optional mailbox list to restore before deleting the cleanup policy. When omitted, every mailbox
+        currently using the target policy is restored.
+    .PARAMETER RestorePolicyName
+        Explicit standard retention policy to assign back to the mailbox or mailboxes.
+    .PARAMETER ClearRetentionPolicy
+        Clear the mailbox retention policy instead of assigning a specific standard policy.
+    .PARAMETER RemoveTag
+        Remove the retention policy tag after the policy has been cleaned up.
+    .PARAMETER RemovePolicy
+        Remove the retention policy after the target mailboxes have been restored.
+    .EXAMPLE
+        Remove-MboxMrmCleanup -Identity OneShot_PreCutoff_20250101
+    .EXAMPLE
+        Remove-MboxMrmCleanup -PolicyName OneShot_PreCutoff_20250101 -RestorePolicyName 'Default MRM Policy'
+    .EXAMPLE
+        'user@contoso.com' | Remove-MboxMrmCleanup -Identity OneShot_PreCutoff_20250101 -ClearRetentionPolicy
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Name', 'TagName', 'PolicyName')]
+        [string[]]$Identity,
+        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Alias('UserPrincipalName', 'IdentityMailbox', 'SourceMailbox')]
+        [string[]]$Mailbox,
+        [string]$RestorePolicyName,
+        [switch]$ClearRetentionPolicy,
+        [bool]$RemoveTag = $true,
+        [bool]$RemovePolicy = $true
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+        $mailboxTargets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $Identity) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+
+        foreach ($entry in $Mailbox) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $mailboxTargets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if (-not (Test-EOLConnection)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
+                return
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($RestorePolicyName) -and $ClearRetentionPolicy.IsPresent) {
+                Write-NCMessage "Use either -RestorePolicyName or -ClearRetentionPolicy, not both." -Level ERROR
+                return
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($RestorePolicyName)) {
+                $restorePolicyCheck = Get-RetentionPolicy -Identity $RestorePolicyName -ErrorAction SilentlyContinue
+                if (-not $restorePolicyCheck) {
+                    Write-NCMessage "Restore policy '$RestorePolicyName' was not found. Use the exact retention policy name." -Level ERROR
+                    return
+                }
+            }
+
+            $tagObjects = @()
+            $policyObjects = @()
+            try {
+                $tagObjects = @(Get-RetentionPolicyTag -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve retention policy tags. $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            try {
+                $policyObjects = @(Get-RetentionPolicy -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to retrieve retention policies. $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            $targetTagNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $targetPolicyNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+            if ($targets.Count -eq 0) {
+                foreach ($tag in $tagObjects) {
+                    if ($tag.Name -like 'OneShot_PreCutoff_*') {
+                        $null = $targetTagNames.Add([string]$tag.Name)
+                    }
+                }
+
+                foreach ($policy in $policyObjects) {
+                    if ($policy.Name -like 'OneShot_PreCutoff_*') {
+                        $null = $targetPolicyNames.Add([string]$policy.Name)
+                    }
+                }
+            }
+            else {
+                foreach ($entry in $targets) {
+                    $tagMatch = $tagObjects | Where-Object { [string]$_.Name -ieq $entry } | Select-Object -First 1
+                    if ($tagMatch) {
+                        $null = $targetTagNames.Add([string]$tagMatch.Name)
+                    }
+
+                    $policyMatch = $policyObjects | Where-Object { [string]$_.Name -ieq $entry } | Select-Object -First 1
+                    if ($policyMatch) {
+                        $null = $targetPolicyNames.Add([string]$policyMatch.Name)
+                    }
+                }
+            }
+
+            if ($targetTagNames.Count -eq 0 -and $targetPolicyNames.Count -eq 0) {
+                Write-NCMessage "No matching retention tags or policies were found." -Level WARNING
+                return
+            }
+
+            $mailboxesToRestore = [System.Collections.Generic.List[object]]::new()
+            $policyNamesToRemove = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($policyName in $targetPolicyNames) {
+                $policy = $policyObjects | Where-Object { [string]$_.Name -ieq $policyName } | Select-Object -First 1
+                if ($policy) {
+                    $null = $policyNamesToRemove.Add([string]$policy.Name)
+                }
+            }
+
+            foreach ($tagName in $targetTagNames) {
+                $tagLinkedPolicies = @($policyObjects | Where-Object { @($_.RetentionPolicyTagLinks) -contains $tagName })
+                foreach ($policy in $tagLinkedPolicies) {
+                    $null = $policyNamesToRemove.Add([string]$policy.Name)
+                }
+            }
+
+            if ($mailboxTargets.Count -gt 0) {
+                foreach ($mailboxIdentity in $mailboxTargets) {
+                    try {
+                        $mailboxObj = Get-Mailbox -Identity $mailboxIdentity -ErrorAction Stop
+                        $mailboxesToRestore.Add($mailboxObj) | Out-Null
+                    }
+                    catch {
+                        Write-NCMessage "Unable to read mailbox '$mailboxIdentity'. $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+            }
+            else {
+                try {
+                    $allMailboxes = @(Get-Mailbox -ResultSize Unlimited -WarningAction SilentlyContinue -ErrorAction Stop)
+                }
+                catch {
+                    Write-NCMessage "Unable to enumerate mailboxes using retention policies. $($_.Exception.Message)" -Level WARNING
+                    $allMailboxes = @()
+                }
+
+                foreach ($mailbox in $allMailboxes) {
+                    if ($policyNamesToRemove.Contains([string]$mailbox.RetentionPolicy)) {
+                        $mailboxesToRestore.Add($mailbox) | Out-Null
+                    }
+                }
+            }
+
+            $restoreTargets = [System.Collections.Generic.List[object]]::new()
+            foreach ($mailbox in $mailboxesToRestore) {
+                if ($null -eq $mailbox) {
+                    continue
+                }
+
+                $mailboxName = if ($mailbox.PrimarySmtpAddress) { [string]$mailbox.PrimarySmtpAddress } else { [string]$mailbox.Identity }
+                $targetPolicy = if (-not [string]::IsNullOrWhiteSpace($RestorePolicyName)) { $RestorePolicyName } else { $null }
+                $action = if ($null -eq $targetPolicy) { 'Clear retention policy back to default' } else { "Restore retention policy '$targetPolicy'" }
+
+                if (-not $PSCmdlet.ShouldProcess($mailboxName, $action)) {
+                    continue
+                }
+
+                try {
+                    Set-Mailbox -Identity $mailbox.Identity -RetentionPolicy $targetPolicy -ErrorAction Stop | Out-Null
+                    $restoreTargets.Add([pscustomobject]@{
+                            Mailbox        = $mailboxName
+                            PreviousPolicy = [string]$mailbox.RetentionPolicy
+                            NewPolicy      = $targetPolicy
+                            Action         = if ($null -eq $targetPolicy) { 'Cleared' } else { 'Restored' }
+                        }) | Out-Null
+                }
+                catch {
+                    Write-NCMessage "Unable to restore retention policy for '$mailboxName'. $($_.Exception.Message)" -Level ERROR
+                }
+            }
+
+            foreach ($policyName in $policyNamesToRemove) {
+                $policy = $policyObjects | Where-Object { [string]$_.Name -ieq $policyName } | Select-Object -First 1
+                if (-not $policy) {
+                    continue
+                }
+
+                $linkedTags = @($policy.RetentionPolicyTagLinks)
+                if ($linkedTags.Count -gt 1) {
+                    Write-NCMessage ("Policy '{0}' has multiple tag links. Review it manually before deletion." -f $policyName) -Level WARNING
+                    continue
+                }
+
+                if ($RemovePolicy -and $PSCmdlet.ShouldProcess($policyName, "Remove retention policy")) {
+                    try {
+                        Remove-RetentionPolicy -Identity $policyName -ErrorAction Stop
+                        Write-NCMessage "Retention policy '$policyName' removed." -Level SUCCESS
+                    }
+                    catch {
+                        Write-NCMessage "Unable to remove retention policy '$policyName'. $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+            }
+
+            if ($RemoveTag) {
+                foreach ($tagName in $targetTagNames) {
+                    $tag = $tagObjects | Where-Object { [string]$_.Name -ieq $tagName } | Select-Object -First 1
+                    if (-not $tag) {
+                        continue
+                    }
+
+                    $linkedPolicies = @($policyObjects | Where-Object { @($_.RetentionPolicyTagLinks) -contains $tagName })
+                    if ($linkedPolicies.Count -gt 0) {
+                        foreach ($policy in $linkedPolicies) {
+                            if ($policyNamesToRemove.Contains([string]$policy.Name)) {
+                                continue
+                            }
+
+                            Write-NCMessage ("Tag '{0}' is still linked to policy '{1}'. Review that policy before deleting the tag." -f $tagName, $policy.Name) -Level WARNING
+                        }
+
+                        if (($linkedPolicies | Where-Object { -not $policyNamesToRemove.Contains([string]$_.Name) }).Count -gt 0) {
+                            continue
+                        }
+                    }
+
+                    if ($PSCmdlet.ShouldProcess($tagName, "Remove retention policy tag")) {
+                        try {
+                            Remove-RetentionPolicyTag -Identity $tagName -ErrorAction Stop
+                            Write-NCMessage "Retention policy tag '$tagName' removed." -Level SUCCESS
+                        }
+                        catch {
+                            Write-NCMessage "Unable to remove retention policy tag '$tagName'. $($_.Exception.Message)" -Level ERROR
+                        }
+                    }
+                }
+            }
+
+            if ($restoreTargets.Count -gt 0) {
+                $restoreCount = $restoreTargets.Count
+                Write-NCMessage ("Restored retention policy for {0} mailbox(es)." -f $restoreCount) -Level SUCCESS
+            }
+
+            if ($restoreTargets.Count -gt 0 -or $policyNamesToRemove.Count -gt 0 -or $targetTagNames.Count -gt 0) {
+                [pscustomobject]@{
+                    RestoredMailboxes = @($restoreTargets)
+                    RemovedPolicies   = @($policyNamesToRemove | Sort-Object)
+                    RemovedTags       = @($targetTagNames | Sort-Object)
+                    RestorePolicyName = $RestorePolicyName
+                    ClearedToDefault  = $ClearRetentionPolicy.IsPresent -or [string]::IsNullOrWhiteSpace($RestorePolicyName)
+                }
+            }
+        }
+        finally {
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
 function Search-MboxCutoffWindow {
     <#
     .SYNOPSIS
@@ -361,6 +861,15 @@ function Set-MboxMrmCleanup {
         Write-NCMessage ("Tag name: {0}" -f $TagName) -Level INFO
         Write-NCMessage ("Policy name: {0}" -f $PolicyName) -Level INFO
 
+        $existingMailboxRetentionPolicy = $null
+        try {
+            $mailboxState = Get-Mailbox -Identity $Mailbox -ErrorAction Stop
+            $existingMailboxRetentionPolicy = [string]$mailboxState.RetentionPolicy
+        }
+        catch {
+            Write-NCMessage "Unable to read current retention policy for '$Mailbox'. Cleanup hints will assume the default policy." -Level WARNING
+        }
+
         try {
             $tag = Get-RetentionPolicyTag -Identity $TagName -ErrorAction SilentlyContinue
             if (-not $tag) {
@@ -434,6 +943,15 @@ function Set-MboxMrmCleanup {
             Write-NCMessage "Managed Folder Assistant not triggered. Use -RunAssistant to start it." -Level INFO
         }
 
+        $escapedPolicyName = $PolicyName -replace "'", "''"
+        $escapedTagName = $TagName -replace "'", "''"
+        $escapedExistingPolicy = if ([string]::IsNullOrWhiteSpace($existingMailboxRetentionPolicy)) {
+            $null
+        }
+        else {
+            $existingMailboxRetentionPolicy -replace "'", "''"
+        }
+
         [pscustomobject]@{
             Mailbox            = $Mailbox
             FixedCutoffDate    = $FixedCutoffDate
@@ -442,9 +960,15 @@ function Set-MboxMrmCleanup {
             RetentionAction    = $RetentionAction
             TagName            = $TagName
             PolicyName         = $PolicyName
-            RollbackCommand    = "Set-Mailbox -Identity '$Mailbox' -RetentionPolicy `$null"
-            RemovePolicyHint   = "Remove-RetentionPolicy -Identity '$PolicyName'"
-            RemoveTagHint      = "Remove-RetentionPolicyTag -Identity '$TagName'"
+            ExistingPolicy     = $existingMailboxRetentionPolicy
+            RollbackCommand    = if ([string]::IsNullOrWhiteSpace($existingMailboxRetentionPolicy)) {
+                "Set-Mailbox -Identity '$Mailbox' -RetentionPolicy `$null"
+            }
+            else {
+                "Set-Mailbox -Identity '$Mailbox' -RetentionPolicy '$escapedExistingPolicy'"
+            }
+            RemovePolicyHint   = "Remove-RetentionPolicy -Identity '$escapedPolicyName'"
+            RemoveTagHint      = "Remove-RetentionPolicyTag -Identity '$escapedTagName'"
         }
     }
 
@@ -452,4 +976,3 @@ function Set-MboxMrmCleanup {
         Restore-ProgressAndInfoPreferences
     }
 }
-

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -457,7 +457,7 @@ function Export-DistributionGroups {
 
             foreach ($group in $groups) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $total
                 Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -640,7 +640,7 @@ function Export-DynamicDistributionGroups {
 
             foreach ($group in $groups) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $total
                 Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -823,7 +823,7 @@ function Export-M365Group {
 
             foreach ($group in $groups) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $total
                 Write-Progress -Activity "Processing $($group.DisplayName)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -1097,7 +1097,7 @@ function Get-RoleGroupsMembers {
 
         foreach ($group in $roleGroups) {
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $total
             Write-Progress -Activity "Processing $($group.Name)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
             try {
@@ -1573,7 +1573,7 @@ function Export-EmptyEntraGroups {
 
             foreach ($group in $groups) {
                 $processedCount++
-                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalGroups, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $totalGroups
                 Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -1622,7 +1622,6 @@ function Export-EmptyEntraGroups {
                 $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-EmptyGroups.csv"
                 $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
                 Write-NCMessage "Empty groups report exported to $csvPath." -Level SUCCESS
-                $csvPath
             }
             else {
                 $report | Sort-Object DisplayName
@@ -2487,3 +2486,5 @@ function Remove-EntraGroupUser {
         }
     }
 }
+
+

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -176,6 +176,838 @@ function Add-EntraGroupDevice {
     }
 }
 
+function Add-EntraGroupOwner {
+    <#
+    .SYNOPSIS
+        Adds one or more owners to an Entra group.
+    .DESCRIPTION
+        Connects to Microsoft Graph, resolves the target group by display name or ID, then adds
+        the provided owners by UPN/display name or object ID. Accepts pipeline input for owners.
+    .PARAMETER GroupName
+        Display name of the Entra group.
+    .PARAMETER GroupId
+        Object ID of the Entra group.
+    .PARAMETER OwnerIdentifier
+        User principal name, display name, or object ID. Accepts pipeline input and common Id/DisplayName property names.
+    .PARAMETER TreatInputAsId
+        Treat every OwnerIdentifier as an object ID without attempting name resolution.
+    .PARAMETER PassThru
+        Emit a summary object for each processed owner.
+    .EXAMPLE
+        "user1@contoso.com","user2@contoso.com" | Add-EntraGroupOwner -GroupName "My Entra Group"
+    .EXAMPLE
+        Add-EntraGroupOwner -GroupId "00000000-0000-0000-0000-000000000000" -OwnerIdentifier "user1@contoso.com"
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName')]
+        [Alias('Group', 'DisplayName')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [string]$GroupId,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner', 'UPN', 'Mail', 'Id', 'UserId', 'Name')]
+        [string[]]$OwnerIdentifier,
+
+        [switch]$TreatInputAsId,
+        [switch]$PassThru
+    )
+
+    begin {
+        $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+        if (-not $graphConnected) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        }
+
+        $owners = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        if (-not $graphConnected) { return }
+
+        foreach ($entry in $OwnerIdentifier) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                [void]$owners.Add($entry.Trim())
+            }
+        }
+    }
+
+    end {
+        if (-not $graphConnected) { return }
+        if ($owners.Count -eq 0) {
+            Write-NCMessage "No owners were specified." -Level WARNING
+            return
+        }
+
+        $resolvedGroup = Resolve-NCEntraGroup -GroupName $GroupName -GroupId $GroupId
+        if (-not $resolvedGroup) {
+            return
+        }
+
+        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+            return
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        $uniqueOwners = $owners | Select-Object -Unique
+
+        foreach ($owner in $uniqueOwners) {
+            $resolvedOwner = Resolve-NCEntraOwner -OwnerIdentifier $owner -TreatInputAsId:$TreatInputAsId
+            if (-not $resolvedOwner) {
+                continue
+            }
+
+            if ($PSCmdlet.ShouldProcess($resolvedGroup.DisplayName, "Add owner '$($resolvedOwner.Label)'")) {
+                $status = 'Added'
+                try {
+                    $body = @{ '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$($resolvedOwner.Id)" } | ConvertTo-Json -Depth 3
+                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($resolvedGroup.Id)/owners/`$ref" -Method POST -Body $body -ContentType 'application/json' | Out-Null
+                    Write-NCMessage "Added owner '$($resolvedOwner.Label)' to group '$($resolvedGroup.DisplayName)'." -Level SUCCESS
+                }
+                catch {
+                    if ($_.Exception.Message -match 'already exist' -or $_.Exception.Message -match 'exists') {
+                        $status = 'Exists'
+                        Write-NCMessage "Owner '$($resolvedOwner.Label)' is already an owner of '$($resolvedGroup.DisplayName)'." -Level WARNING
+                    }
+                    else {
+                        $status = 'Failed'
+                        Write-NCMessage "Failed to add owner '$($resolvedOwner.Label)' to '$($resolvedGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+
+                if ($PassThru.IsPresent) {
+                    $results.Add([pscustomobject][ordered]@{
+                            GroupName = $resolvedGroup.DisplayName
+                            GroupId   = $resolvedGroup.Id
+                            OwnerName = $resolvedOwner.Label
+                            OwnerId   = $resolvedOwner.Id
+                            Status    = $status
+                        }) | Out-Null
+                }
+            }
+        }
+
+        if ($PassThru.IsPresent -and $results.Count -gt 0) {
+            $results
+        }
+    }
+}
+
+function Remove-EntraGroupOwner {
+    <#
+    .SYNOPSIS
+        Removes one or more owners from an Entra group.
+    .DESCRIPTION
+        Connects to Microsoft Graph, resolves the target group by display name or ID, then removes
+        the provided owners by UPN/display name or object ID. Accepts pipeline input for owners.
+    .PARAMETER GroupName
+        Display name of the Entra group.
+    .PARAMETER GroupId
+        Object ID of the Entra group.
+    .PARAMETER OwnerIdentifier
+        User principal name, display name, or object ID. Accepts pipeline input and common Id/DisplayName property names.
+    .PARAMETER ClearAll
+        Remove all owners from the Entra group.
+    .PARAMETER TreatInputAsId
+        Treat every OwnerIdentifier as an object ID without attempting name resolution.
+    .PARAMETER PassThru
+        Emit a summary object for each processed owner.
+    .EXAMPLE
+        "user1@contoso.com","user2@contoso.com" | Remove-EntraGroupOwner -GroupName "My Entra Group"
+    .EXAMPLE
+        Remove-EntraGroupOwner -GroupId "00000000-0000-0000-0000-000000000000" -OwnerIdentifier "user1@contoso.com"
+    .EXAMPLE
+        Remove-EntraGroupOwner -GroupName "My Entra Group" -ClearAll
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllByName')]
+        [Alias('Group', 'DisplayName')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllById')]
+        [string]$GroupId,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Owner', 'UPN', 'Mail', 'Id', 'UserId', 'Name')]
+        [string[]]$OwnerIdentifier,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllByName')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearAllById')]
+        [switch]$ClearAll,
+
+        [switch]$TreatInputAsId,
+        [switch]$PassThru
+    )
+
+    begin {
+        $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+        if (-not $graphConnected) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        }
+
+        $owners = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        if (-not $graphConnected) { return }
+        if ($ClearAll.IsPresent) { return }
+
+        foreach ($entry in $OwnerIdentifier) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                [void]$owners.Add($entry.Trim())
+            }
+        }
+    }
+
+    end {
+        if (-not $graphConnected) { return }
+        if (-not $ClearAll.IsPresent -and $owners.Count -eq 0) {
+            Write-NCMessage "No owners were specified." -Level WARNING
+            return
+        }
+
+        $resolvedGroup = Resolve-NCEntraGroup -GroupName $GroupName -GroupId $GroupId
+        if (-not $resolvedGroup) {
+            return
+        }
+
+        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+            return
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        $ownersToRemove = [System.Collections.Generic.List[object]]::new()
+
+        if ($ClearAll.IsPresent) {
+            $confirmMessage = "You are about to remove ALL owners from '$($resolvedGroup.DisplayName)'. This is a high-risk operation."
+            if (-not $PSCmdlet.ShouldContinue($confirmMessage, "Confirm ClearAll")) {
+                Write-NCMessage "ClearAll operation cancelled." -Level WARNING
+                return
+            }
+
+            try {
+                $ownerResponse = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($resolvedGroup.Id)/owners?`$select=id,displayName,userPrincipalName,appDisplayName" -Method GET
+                $ownerItems = @()
+                if ($ownerResponse -and $ownerResponse.PSObject.Properties['value']) {
+                    $ownerItems = @($ownerResponse.value)
+                }
+                elseif ($ownerResponse) {
+                    $ownerItems = @($ownerResponse)
+                }
+            }
+            catch {
+                Write-NCMessage "Unable to read owners for group $($resolvedGroup.DisplayName): $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            foreach ($ownerItem in $ownerItems) {
+                $ownerId = if ($ownerItem.PSObject.Properties['id']) { [string]$ownerItem.id } else { $null }
+                if ([string]::IsNullOrWhiteSpace($ownerId)) {
+                    continue
+                }
+
+                $ownersToRemove.Add([pscustomobject]@{
+                        Id    = $ownerId
+                        Label = (Get-NCGraphObjectLabel -InputObject $ownerItem)
+                    }) | Out-Null
+            }
+
+            if ($ownersToRemove.Count -eq 0) {
+                Write-NCMessage "No owners found for $($resolvedGroup.DisplayName)." -Level WARNING
+                return
+            }
+        }
+        else {
+            $uniqueOwners = $owners | Select-Object -Unique
+
+            foreach ($owner in $uniqueOwners) {
+                $resolvedOwner = Resolve-NCEntraOwner -OwnerIdentifier $owner -TreatInputAsId:$TreatInputAsId
+                if (-not $resolvedOwner) {
+                    continue
+                }
+
+                $ownersToRemove.Add([pscustomobject]@{
+                        Id    = $resolvedOwner.Id
+                        Label = $resolvedOwner.Label
+                    }) | Out-Null
+            }
+        }
+
+        foreach ($entry in $ownersToRemove) {
+            if ($PSCmdlet.ShouldProcess($resolvedGroup.DisplayName, "Remove owner '$($entry.Label)'")) {
+                $status = 'Removed'
+                try {
+                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($resolvedGroup.Id)/owners/$($entry.Id)/`$ref" -Method DELETE | Out-Null
+                    Write-NCMessage "Removed owner '$($entry.Label)' from group '$($resolvedGroup.DisplayName)'." -Level SUCCESS
+                }
+                catch {
+                    if ($_.Exception.Message -match 'could not find' -or $_.Exception.Message -match 'does not exist') {
+                        $status = 'NotFound'
+                        Write-NCMessage "Owner '$($entry.Label)' is not an owner of '$($resolvedGroup.DisplayName)'." -Level WARNING
+                    }
+                    else {
+                        $status = 'Failed'
+                        Write-NCMessage "Failed to remove owner '$($entry.Label)' from '$($resolvedGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+
+                if ($PassThru.IsPresent) {
+                    $results.Add([pscustomobject][ordered]@{
+                            GroupName = $resolvedGroup.DisplayName
+                            GroupId   = $resolvedGroup.Id
+                            OwnerName = $entry.Label
+                            OwnerId   = $entry.Id
+                            Status    = $status
+                        }) | Out-Null
+                }
+            }
+        }
+
+        if ($PassThru.IsPresent -and $results.Count -gt 0) {
+            $results
+        }
+    }
+}
+
+function Copy-EntraGroupOwner {
+    <#
+    .SYNOPSIS
+        Copies owners from one Entra group to another.
+    .DESCRIPTION
+        Reads the owners of a source Entra group and adds any missing owners to the destination
+        group without removing existing destination owners.
+    .PARAMETER SourceGroupName
+        Display name of the source Entra group.
+    .PARAMETER SourceGroupId
+        Object ID of the source Entra group.
+    .PARAMETER DestinationGroupName
+        Display name of the destination Entra group.
+    .PARAMETER DestinationGroupId
+        Object ID of the destination Entra group.
+    .PARAMETER PassThru
+        Emit a summary object for each copied owner.
+    .EXAMPLE
+        Copy-EntraGroupOwner -SourceGroupName "HR" -DestinationGroupName "HR - Test"
+    .EXAMPLE
+        Copy-EntraGroupOwner -SourceGroupId "00000000-0000-0000-0000-000000000000" -DestinationGroupId "11111111-1111-1111-1111-111111111111"
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'ByName')]
+        [Alias('Source', 'From')]
+        [string]$SourceGroupName,
+
+        [Parameter(Mandatory = $true, Position = 0, ParameterSetName = 'ById')]
+        [string]$SourceGroupId,
+
+        [Parameter(Mandatory = $true, Position = 1, ParameterSetName = 'ByName')]
+        [Alias('Destination', 'To')]
+        [string]$DestinationGroupName,
+
+        [Parameter(Mandatory = $true, Position = 1, ParameterSetName = 'ById')]
+        [string]$DestinationGroupId,
+
+        [switch]$PassThru
+    )
+
+    $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+    if (-not $graphConnected) {
+        Add-EmptyLine
+        Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        return
+    }
+
+    if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+        Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+        return
+    }
+
+    $sourceGroup = if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        Resolve-NCEntraGroup -GroupName $SourceGroupId -GroupId $SourceGroupId
+    }
+    else {
+        Resolve-NCEntraGroup -GroupName $SourceGroupName
+    }
+
+    if (-not $sourceGroup) {
+        return
+    }
+
+    $destinationGroup = if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        Resolve-NCEntraGroup -GroupName $DestinationGroupId -GroupId $DestinationGroupId
+    }
+    else {
+        Resolve-NCEntraGroup -GroupName $DestinationGroupName
+    }
+
+    if (-not $destinationGroup) {
+        return
+    }
+
+    if ($sourceGroup.Id -eq $destinationGroup.Id) {
+        Write-NCMessage "Source and destination groups are the same. Aborting." -Level ERROR
+        return
+    }
+
+    try {
+        $ownerResponse = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($sourceGroup.Id)/owners?`$select=id,displayName,userPrincipalName,appDisplayName" -Method GET
+        $sourceOwners = @()
+        if ($ownerResponse -and $ownerResponse.PSObject.Properties['value']) {
+            $sourceOwners = @($ownerResponse.value)
+        }
+        elseif ($ownerResponse) {
+            $sourceOwners = @($ownerResponse)
+        }
+    }
+    catch {
+        Write-NCMessage "Unable to read owners for source group $($sourceGroup.DisplayName): $($_.Exception.Message)" -Level ERROR
+        return
+    }
+
+    if ($sourceOwners.Count -eq 0) {
+        Write-NCMessage "Source group $($sourceGroup.DisplayName) has no owners to copy." -Level WARNING
+        return
+    }
+
+    try {
+        $destinationOwnerResponse = Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)/owners?`$select=id" -Method GET
+        $destinationOwners = @()
+        if ($destinationOwnerResponse -and $destinationOwnerResponse.PSObject.Properties['value']) {
+            $destinationOwners = @($destinationOwnerResponse.value)
+        }
+        elseif ($destinationOwnerResponse) {
+            $destinationOwners = @($destinationOwnerResponse)
+        }
+    }
+    catch {
+        Write-NCMessage "Unable to read owners for destination group $($destinationGroup.DisplayName): $($_.Exception.Message)" -Level ERROR
+        return
+    }
+
+    $destinationOwnerIds = @($destinationOwners | ForEach-Object { [string]$_.id })
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($ownerItem in $sourceOwners) {
+        $ownerId = if ($ownerItem.PSObject.Properties['id']) { [string]$ownerItem.id } else { $null }
+        if ([string]::IsNullOrWhiteSpace($ownerId)) {
+            continue
+        }
+
+        $ownerLabel = Get-NCGraphObjectLabel -InputObject $ownerItem
+        if ($destinationOwnerIds -contains $ownerId) {
+            if ($PassThru.IsPresent) {
+                $results.Add([pscustomobject][ordered]@{
+                        SourceGroup      = $sourceGroup.DisplayName
+                        DestinationGroup = $destinationGroup.DisplayName
+                        OwnerName        = $ownerLabel
+                        OwnerId          = $ownerId
+                        Status           = 'Exists'
+                    }) | Out-Null
+            }
+            continue
+        }
+
+        if ($PSCmdlet.ShouldProcess($destinationGroup.DisplayName, "Copy owner '$ownerLabel' from '$($sourceGroup.DisplayName)'")) {
+            $status = 'Added'
+            try {
+                $body = @{ '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$ownerId" } | ConvertTo-Json -Depth 3
+                Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)/owners/`$ref" -Method POST -Body $body -ContentType 'application/json' | Out-Null
+                Write-NCMessage "Copied owner '$ownerLabel' to '$($destinationGroup.DisplayName)'." -Level SUCCESS
+            }
+            catch {
+                if ($_.Exception.Message -match 'already exist' -or $_.Exception.Message -match 'exists') {
+                    $status = 'Exists'
+                    Write-NCMessage "Owner '$ownerLabel' is already an owner of '$($destinationGroup.DisplayName)'." -Level WARNING
+                }
+                else {
+                    $status = 'Failed'
+                    Write-NCMessage "Failed to copy owner '$ownerLabel' to '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                }
+            }
+
+            if ($PassThru.IsPresent) {
+                $results.Add([pscustomobject][ordered]@{
+                        SourceGroup      = $sourceGroup.DisplayName
+                        DestinationGroup = $destinationGroup.DisplayName
+                        OwnerName        = $ownerLabel
+                        OwnerId          = $ownerId
+                        Status           = $status
+                    }) | Out-Null
+            }
+        }
+    }
+
+    if ($PassThru.IsPresent -and $results.Count -gt 0) {
+        $results
+    }
+}
+
+function Copy-EntraGroup {
+    <#
+    .SYNOPSIS
+        Clones an Entra group into a new or existing group.
+    .DESCRIPTION
+        Copies the source group's core properties, owners, and members into the destination.
+        If the destination group name does not already exist, a new group is created first.
+        Dynamic membership groups are cloned as a static snapshot of their current members.
+    .PARAMETER SourceGroupName
+        Display name of the source Entra group.
+    .PARAMETER SourceGroupId
+        Object ID of the source Entra group.
+    .PARAMETER DestinationGroupName
+        Display name of the destination Entra group. If no group with this name exists, a new
+        group is created with this name.
+    .PARAMETER DestinationGroupId
+        Object ID of an existing destination Entra group.
+    .PARAMETER SkipMembers
+        Do not copy members.
+    .PARAMETER SkipOwners
+        Do not copy owners.
+    .PARAMETER SkipDescription
+        Do not copy the source description.
+    .PARAMETER PassThru
+        Emit a summary object for the clone operation.
+    .EXAMPLE
+        Copy-EntraGroup -SourceGroupName "GitLab-Prod" -DestinationGroupName "GitLab-Prod-Test"
+    .EXAMPLE
+        Copy-EntraGroup -SourceGroupName "GitLab-Prod" -DestinationGroupName "GitLab-Prod-Test" -SkipOwners
+    .EXAMPLE
+        Copy-EntraGroup -SourceGroupId "00000000-0000-0000-0000-000000000000" -DestinationGroupId "11111111-1111-1111-1111-111111111111" -PassThru
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByName', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0)]
+        [Alias('Source', 'From')]
+        [string]$SourceGroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 0)]
+        [string]$SourceGroupId,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 1)]
+        [Alias('Destination', 'To')]
+        [string]$DestinationGroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById', Position = 1)]
+        [string]$DestinationGroupId,
+
+        [switch]$SkipMembers,
+        [switch]$SkipOwners,
+        [switch]$SkipDescription,
+        [switch]$PassThru
+    )
+
+    begin {
+        $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+        if (-not $graphConnected) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+            return
+        }
+
+        if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+            return
+        }
+    }
+
+    process {
+        $sourceResolved = if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            Resolve-NCEntraGroup -GroupName $SourceGroupId -GroupId $SourceGroupId
+        }
+        else {
+            Resolve-NCEntraGroup -GroupName $SourceGroupName
+        }
+
+        if (-not $sourceResolved) {
+            return
+        }
+
+        try {
+            $sourceGroup = Get-MgGroup -GroupId $sourceResolved.Id -Property @(
+                    'id',
+                    'displayName',
+                    'description',
+                    'groupTypes',
+                    'mailEnabled',
+                    'mailNickname',
+                    'securityEnabled',
+                    'visibility',
+                    'onPremisesSyncEnabled',
+                    'isAssignableToRole'
+                ) -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Unable to retrieve full details for source group '$($sourceResolved.DisplayName)': $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        if ($sourceGroup.IsAssignableToRole -eq $true) {
+            Write-NCMessage "Role-assignable groups are not supported by Copy-EntraGroup yet." -Level ERROR
+            return
+        }
+
+        if (($sourceGroup.MailEnabled -eq $true) -and ($sourceGroup.SecurityEnabled -eq $false) -and (-not $sourceGroup.GroupTypes -or ($sourceGroup.GroupTypes.Count -eq 0))) {
+            Write-NCMessage "Distribution groups are not supported by Copy-EntraGroup. Use the distribution-group helpers instead." -Level ERROR
+            return
+        }
+
+        $destinationCreated = $false
+        $destinationGroup = $null
+
+        if ($PSCmdlet.ParameterSetName -eq 'ById') {
+            try {
+                $destinationGroup = Get-MgGroup -GroupId $DestinationGroupId -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Destination Entra group with ID '$DestinationGroupId' not found: $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+        else {
+            $escapedName = $DestinationGroupName.Replace("'", "''")
+            try {
+                $destinationGroup = Get-MgGroup -Filter "displayName eq '$escapedName'" -All -ErrorAction Stop | Select-Object -First 1
+            }
+            catch {
+                Write-NCMessage "Unable to resolve destination group '$DestinationGroupName': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            if (-not $destinationGroup) {
+                $destinationCreated = $true
+            }
+        }
+
+        if ($destinationGroup -and $destinationGroup.Id -eq $sourceGroup.Id) {
+            Write-NCMessage "Source and destination groups are the same. Aborting." -Level ERROR
+            return
+        }
+
+        $destinationDisplayName = if ($destinationCreated) { $DestinationGroupName } else { $destinationGroup.DisplayName }
+        $operationLabel = if ($destinationCreated) {
+            "Create and clone group '$($sourceGroup.DisplayName)' into '$DestinationGroupName'"
+        }
+        else {
+            "Clone group '$($sourceGroup.DisplayName)' into existing group '$($destinationDisplayName)'"
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($destinationDisplayName, $operationLabel)) {
+            return
+        }
+
+        if ($destinationCreated) {
+            $createGroupTypes = @()
+            if ($sourceGroup.GroupTypes) {
+                $createGroupTypes = @($sourceGroup.GroupTypes | Where-Object { $_ -ne 'DynamicMembership' })
+                if ($sourceGroup.GroupTypes -contains 'DynamicMembership') {
+                    Write-NCMessage "Source group '$($sourceGroup.DisplayName)' is dynamic; the cloned group will be a static snapshot of its current members." -Level WARNING
+                }
+            }
+
+            $mailNickname = [regex]::Replace($DestinationGroupName, '[^a-zA-Z0-9]', '')
+            if ([string]::IsNullOrWhiteSpace($mailNickname)) {
+                $mailNickname = "group$((Get-Date).ToString('yyyyMMddHHmmss'))"
+            }
+
+            $createBody = [ordered]@{
+                displayName     = $DestinationGroupName
+                mailEnabled     = [bool]$sourceGroup.MailEnabled
+                mailNickname    = $mailNickname
+                securityEnabled = [bool]$sourceGroup.SecurityEnabled
+            }
+
+            if (-not $SkipDescription.IsPresent -and -not [string]::IsNullOrWhiteSpace($sourceGroup.Description)) {
+                $createBody.description = $sourceGroup.Description
+            }
+
+            if ($createGroupTypes.Count -gt 0) {
+                $createBody.groupTypes = $createGroupTypes
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($sourceGroup.Visibility)) {
+                $createBody.visibility = $sourceGroup.Visibility
+            }
+
+            try {
+                $destinationGroup = Invoke-MgGraphRequest -Uri 'https://graph.microsoft.com/v1.0/groups' -Method POST -Body ($createBody | ConvertTo-Json -Depth 10) -ContentType 'application/json'
+                $destinationCreated = $true
+                Write-NCMessage "Created destination group '$DestinationGroupName' for clone operation." -Level SUCCESS
+            }
+            catch {
+                Write-NCMessage "Failed to create destination group '$DestinationGroupName': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+        else {
+            if (-not $SkipDescription.IsPresent -and -not [string]::IsNullOrWhiteSpace($sourceGroup.Description) -and $sourceGroup.Description -ne $destinationGroup.Description) {
+                try {
+                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)" -Method PATCH -Body (@{ description = $sourceGroup.Description } | ConvertTo-Json -Depth 10) -ContentType 'application/json' | Out-Null
+                    Write-NCMessage "Copied description to '$($destinationGroup.DisplayName)'." -Level SUCCESS
+                }
+                catch {
+                    Write-NCMessage "Unable to copy description to '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level WARNING
+                }
+            }
+        }
+
+        if ($destinationGroup.OnPremisesSyncEnabled -eq $true) {
+            Write-NCMessage "Destination group '$($destinationGroup.DisplayName)' is synchronized from on-premises AD and cannot be modified directly in Entra." -Level ERROR
+            return
+        }
+
+        try {
+            $destinationMembers = @(Get-MgGroupMember -GroupId $destinationGroup.Id -All -ErrorAction Stop)
+        }
+        catch {
+            Write-NCMessage "Unable to read destination members for '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        $destinationMemberIds = @($destinationMembers | ForEach-Object { [string]$_.Id })
+        $destinationOwnerIds = @()
+
+        if (-not $SkipOwners.IsPresent) {
+            try {
+                $destinationOwnerUri = "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)/owners?`$select=id,displayName,userPrincipalName,appDisplayName"
+                $destinationOwnerItems = @(Invoke-NCGraphAllPagesCore -Uri $destinationOwnerUri)
+                $destinationOwnerIds = @($destinationOwnerItems | ForEach-Object { [string]$_.id })
+            }
+            catch {
+                Write-NCMessage "Unable to read destination owners for '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+
+        $memberCopied = 0
+        $memberSkipped = 0
+        $ownerCopied = 0
+        $ownerSkipped = 0
+
+        if (-not $SkipOwners.IsPresent) {
+            try {
+                $sourceOwnerUri = "https://graph.microsoft.com/v1.0/groups/$($sourceGroup.Id)/owners?`$select=id,displayName,userPrincipalName,appDisplayName"
+                $sourceOwners = @(Invoke-NCGraphAllPagesCore -Uri $sourceOwnerUri)
+            }
+            catch {
+                Write-NCMessage "Unable to read source owners for '$($sourceGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            foreach ($owner in $sourceOwners) {
+                $ownerId = if ($owner.PSObject.Properties['id']) { [string]$owner.id } else { $null }
+                if ([string]::IsNullOrWhiteSpace($ownerId)) {
+                    continue
+                }
+
+                if ($destinationOwnerIds -contains $ownerId) {
+                    $ownerSkipped++
+                    continue
+                }
+
+                $ownerLabel = Get-NCGraphObjectLabel -InputObject $owner
+                try {
+                    $body = @{ '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$ownerId" } | ConvertTo-Json -Depth 3
+                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)/owners/`$ref" -Method POST -Body $body -ContentType 'application/json' | Out-Null
+                    $ownerCopied++
+                    Write-NCMessage "Copied owner '$ownerLabel' to '$($destinationGroup.DisplayName)'." -Level SUCCESS
+                }
+                catch {
+                    if ($_.Exception.Message -match 'already exist' -or $_.Exception.Message -match 'exists') {
+                        $ownerSkipped++
+                        Write-NCMessage "Owner '$ownerLabel' is already an owner of '$($destinationGroup.DisplayName)'." -Level WARNING
+                    }
+                    else {
+                        Write-NCMessage "Failed to copy owner '$ownerLabel' to '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+            }
+        }
+
+        if (-not $SkipMembers.IsPresent) {
+            try {
+                $sourceMembers = @(Get-MgGroupMember -GroupId $sourceGroup.Id -All -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to read source members for '$($sourceGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            $resolveType = {
+                param($odataType)
+                if ([string]::IsNullOrWhiteSpace($odataType)) {
+                    return 'DirectoryObject'
+                }
+
+                $value = $odataType.ToLowerInvariant()
+                if ($value -match 'user') { return 'User' }
+                if ($value -match 'device') { return 'Device' }
+                if ($value -match 'group') { return 'Group' }
+                if ($value -match 'serviceprincipal') { return 'ServicePrincipal' }
+                if ($value -match 'orgcontact') { return 'Contact' }
+                return 'DirectoryObject'
+            }
+
+            foreach ($member in $sourceMembers) {
+                $memberId = if ($member.PSObject.Properties['id']) { [string]$member.id } else { $null }
+                if ([string]::IsNullOrWhiteSpace($memberId)) {
+                    continue
+                }
+
+                if ($destinationMemberIds -contains $memberId) {
+                    $memberSkipped++
+                    continue
+                }
+
+                $memberProps = if ($member.AdditionalProperties) { $member.AdditionalProperties } else { @{} }
+                $memberType = if ($memberProps.ContainsKey('@odata.type')) { & $resolveType $memberProps['@odata.type'] } else { 'DirectoryObject' }
+                $memberLabel = if ($memberProps.ContainsKey('displayName')) { $memberProps.displayName } elseif ($memberProps.ContainsKey('userPrincipalName')) { $memberProps.userPrincipalName } else { $memberId }
+
+                try {
+                    $body = @{ '@odata.id' = "https://graph.microsoft.com/v1.0/directoryObjects/$memberId" } | ConvertTo-Json -Depth 3
+                    Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($destinationGroup.Id)/members/`$ref" -Method POST -Body $body -ContentType 'application/json' | Out-Null
+                    $memberCopied++
+                    Write-NCMessage "Copied $memberType '$memberLabel' to '$($destinationGroup.DisplayName)'." -Level SUCCESS
+                }
+                catch {
+                    if ($_.Exception.Message -match 'already exist' -or $_.Exception.Message -match 'exists') {
+                        $memberSkipped++
+                        Write-NCMessage "$memberType '$memberLabel' is already a member of '$($destinationGroup.DisplayName)'." -Level WARNING
+                    }
+                    else {
+                        Write-NCMessage "Failed to copy $memberType '$memberLabel' to '$($destinationGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+            }
+        }
+
+        if ($PassThru.IsPresent) {
+            [pscustomobject][ordered]@{
+                SourceGroupName      = $sourceGroup.DisplayName
+                SourceGroupId        = $sourceGroup.Id
+                DestinationGroupName = $destinationGroup.DisplayName
+                DestinationGroupId   = $destinationGroup.Id
+                DestinationCreated   = $destinationCreated
+                MembersCopied        = $memberCopied
+                MembersSkipped       = $memberSkipped
+                OwnersCopied         = $ownerCopied
+                OwnersSkipped        = $ownerSkipped
+                Status               = 'Completed'
+            }
+        }
+    }
+}
+
 function Add-EntraGroupUser {
     <#
     .SYNOPSIS
@@ -274,6 +1106,19 @@ function Add-EntraGroupUser {
             }
         }
 
+        try {
+            $resolvedGroup = Get-MgGroup -GroupId $resolvedGroup.Id -Property @('id', 'displayName', 'onPremisesSyncEnabled') -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Unable to retrieve full details for group '$($resolvedGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        if ($resolvedGroup.OnPremisesSyncEnabled -eq $true) {
+            Write-NCMessage "Group '$($resolvedGroup.DisplayName)' is synchronized from on-premises AD, so membership can't be changed directly in Entra. Update the group in AD and let sync propagate the change." -Level ERROR
+            return
+        }
+
         $results = [System.Collections.Generic.List[object]]::new()
         $uniqueUsers = $users | Select-Object -Unique
 
@@ -329,6 +1174,10 @@ function Add-EntraGroupUser {
                     if ($_.Exception.Message -match 'added object references already exist') {
                         $status = 'Exists'
                         Write-NCMessage "User '$userLabel' is already a member of '$($resolvedGroup.DisplayName)'." -Level WARNING
+                    }
+                    elseif ($_.Exception.Message -match 'on-premises mastered Directory Sync objects|currently undergoing migration') {
+                        $status = 'Failed'
+                        Write-NCMessage "Group '$($resolvedGroup.DisplayName)' is synchronized from on-premises AD, so membership can't be changed directly in Entra. Update the group in AD and let sync propagate the change." -Level ERROR
                     }
                     else {
                         $status = 'Failed'
@@ -1097,6 +1946,116 @@ function Export-DynamicDistributionGroups {
 
 Set-Alias -Name Export-DDG -Value Export-DynamicDistributionGroups
 
+function Export-EmptyEntraGroups {
+    <#
+    .SYNOPSIS
+        Exports Entra groups that have no members.
+    .DESCRIPTION
+        Connects to Microsoft Graph, enumerates groups, checks membership for each one, and exports
+        the groups with zero members to CSV by default.
+    .PARAMETER CsvFolder
+        Destination folder for the CSV file when exporting the report.
+    .PARAMETER Csv
+        When present, export the report to CSV. Defaults to on.
+    .EXAMPLE
+        Export-EmptyEntraGroups
+    .EXAMPLE
+        Export-EmptyEntraGroups -CsvFolder 'C:\Reports\Groups'
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$CsvFolder,
+        [bool]$Csv = $true
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $report = [System.Collections.Generic.List[object]]::new()
+    }
+
+    process {
+        try {
+            if (-not (Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $groups = @(Get-MgGroup -All -ErrorAction Stop)
+            if (-not $groups -or $groups.Count -eq 0) {
+                Write-NCMessage "No Entra groups found." -Level WARNING
+                return
+            }
+
+            $totalGroups = $groups.Count
+            $processedCount = 0
+
+            foreach ($group in $groups) {
+                $processedCount++
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $totalGroups
+                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups - $Percentage%" -PercentComplete $Percentage
+
+                try {
+                    $members = @(Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop)
+                }
+                catch {
+                    Write-NCMessage "Unable to read members for group '$($group.DisplayName)'. $($_.Exception.Message)" -Level WARNING
+                    continue
+                }
+
+                if ($members.Count -gt 0) {
+                    continue
+                }
+
+                $groupType = if ($group.GroupTypes -contains 'Unified' -and $group.SecurityEnabled) {
+                    'Microsoft 365 (security-enabled)'
+                }
+                elseif ($group.GroupTypes -contains 'Unified' -and -not $group.SecurityEnabled) {
+                    'Microsoft 365'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled -and $group.MailEnabled) {
+                    'Mail-enabled security'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled) {
+                    'Security'
+                }
+                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.MailEnabled) {
+                    'Distribution'
+                }
+                else {
+                    'N/A'
+                }
+
+                $report.Add([pscustomobject][ordered]@{
+                        DisplayName     = $group.DisplayName
+                        Id              = $group.Id
+                        GroupType       = $groupType
+                        MemberCount     = 0
+                        MailEnabled     = $group.MailEnabled
+                        SecurityEnabled = $group.SecurityEnabled
+                    }) | Out-Null
+            }
+
+            if ($Csv) {
+                $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
+                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-EmptyGroups.csv"
+                $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                Write-NCMessage "Empty groups report exported to $csvPath." -Level SUCCESS
+            }
+            else {
+                $report | Sort-Object DisplayName
+            }
+        }
+        catch {
+            Write-NCMessage "Unable to export empty Entra groups. $($_.Exception.Message)" -Level ERROR
+        }
+        finally {
+            Write-Progress -Activity "Checking empty Entra groups" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
 function Export-M365Group {
     <#
     .SYNOPSIS
@@ -1598,6 +2557,459 @@ function Get-DynamicDistributionGroupFilter {
 
 Set-Alias -Name Get-DDGRecipientFilter -Value Get-DynamicDistributionGroupFilter
 
+function Get-EntraGroupDevice {
+    <#
+    .SYNOPSIS
+        Shows the Entra groups that a device belongs to.
+    .DESCRIPTION
+        Connects to Microsoft Graph, resolves the target device by display name or ID, then
+        lists every directory object membership for that device.
+    .PARAMETER DeviceIdentifier
+        Device display name or object ID. Accepts pipeline input and common Id/DisplayName property names.
+    .PARAMETER TreatInputAsId
+        Treat the provided DeviceIdentifier as an object ID without attempting name resolution.
+    .PARAMETER GridView
+        Show additional details in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Get-EntraGroupDevice -DeviceIdentifier "PC123"
+    .EXAMPLE
+        "00000000-0000-0000-0000-000000000000" | Get-EntraGroupDevice -TreatInputAsId -GridView
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Device', 'DeviceName', 'Id', 'DeviceId', 'Name', 'Identity', 'DisplayName')]
+        [string]$DeviceIdentifier,
+        [switch]$TreatInputAsId,
+        [switch]$GridView
+    )
+
+    begin {
+        $graphConnected = $null
+    }
+
+    process {
+        if ($null -eq $graphConnected) {
+            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+            if (-not $graphConnected) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+        }
+
+        $device = $null
+        $deviceLabel = $DeviceIdentifier
+
+        if ($TreatInputAsId.IsPresent -or $DeviceIdentifier -match '^[0-9a-fA-F-]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+            try {
+                $device = Get-MgDevice -DeviceId $DeviceIdentifier -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Entra device with ID '$DeviceIdentifier' not found: $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+        else {
+            $escapedDevice = $DeviceIdentifier.Replace("'", "''")
+            try {
+                $deviceMatches = Get-MgDevice -Filter "displayName eq '$escapedDevice'" -All -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Unable to resolve device '$DeviceIdentifier': $($_.Exception.Message)" -Level ERROR
+                return
+            }
+
+            if (-not $deviceMatches -or $deviceMatches.Count -eq 0) {
+                Write-NCMessage "Device '$DeviceIdentifier' not found" -Level WARNING
+                return
+            }
+
+            if ($deviceMatches.Count -gt 1) {
+                Write-NCMessage "Multiple devices matched '$DeviceIdentifier'. Using the first result ($($deviceMatches[0].DisplayName))" -Level WARNING
+            }
+
+            $device = $deviceMatches | Select-Object -First 1
+            $deviceLabel = $device.DisplayName
+        }
+
+        if (-not $device) {
+            return
+        }
+
+        try {
+            $memberships = @(Get-MgDeviceMemberOf -DeviceId $device.Id -All -ErrorAction Stop)
+        }
+        catch {
+            Write-NCMessage "Unable to read group memberships for device ${deviceLabel}: $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        Add-EmptyLine
+        Write-Verbose "Device ($deviceLabel) - Groups found: $($memberships.Count)"
+
+        if (-not $memberships -or $memberships.Count -eq 0) {
+            Write-NCMessage "No groups found for $deviceLabel." -Level WARNING
+            return
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        foreach ($membership in $memberships) {
+            $props = if ($membership.AdditionalProperties) { $membership.AdditionalProperties } else { @{} }
+            $row = [ordered]@{
+                'Group Name' = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
+                'Group Mail' = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
+            }
+
+            if ($GridView.IsPresent) {
+                $row['Group Description'] = if ($props.ContainsKey('description')) { $props.description } else { $null }
+                $row['Group Mail Nickname'] = if ($props.ContainsKey('mailNickname')) { $props.mailNickname } else { $null }
+                $row['Group Mail Enabled'] = if ($props.ContainsKey('mailEnabled')) { $props.mailEnabled } else { $null }
+                $row['Group Type'] = if ($props.ContainsKey('groupTypes')) { ($props.groupTypes -join ', ') } else { $null }
+                $row['Group ID'] = $membership.Id
+            }
+
+            $results.Add([pscustomobject]$row) | Out-Null
+        }
+
+        if ($GridView.IsPresent) {
+            $results | Out-GridView -Title "Entra Device Groups - $deviceLabel"
+        }
+        else {
+            $results | Sort-Object 'Group Name'
+        }
+    }
+}
+
+function Get-EntraGroupMembers {
+    <#
+    .SYNOPSIS
+        Shows the members of an Entra group (users, devices, and other directory objects).
+    .DESCRIPTION
+        Connects to Microsoft Graph, resolves the target group by display name or ID, then
+        lists every member of that group regardless of type.
+    .PARAMETER GroupName
+        Display name of the Entra group.
+    .PARAMETER GroupId
+        Object ID of the Entra group.
+    .PARAMETER IncludeDeviceUsers
+        When members are devices, resolve registered owners and users (may require additional Graph calls).
+    .PARAMETER GridView
+        Show additional details in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Get-EntraGroupMembers -GroupName "My Entra Group"
+    .EXAMPLE
+        Get-EntraGroupMembers -GroupId "00000000-0000-0000-0000-000000000000" -GridView
+    .EXAMPLE
+        "My Entra Group" | Get-EntraGroupMembers
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'ByName')]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('Group', 'DisplayName', 'Name', 'Identity')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [string]$GroupId,
+
+        [switch]$IncludeDeviceUsers,
+        [switch]$GridView
+    )
+
+    $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+    if (-not $graphConnected) {
+        Add-EmptyLine
+        Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        return
+    }
+
+    $resolvedGroup = $null
+    if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        try {
+            $resolvedGroup = Get-MgGroup -GroupId $GroupId -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Entra group with ID '$GroupId' not found: $($_.Exception.Message)" -Level ERROR
+            return
+        }
+    }
+    else {
+        $escapedName = $GroupName.Replace("'", "''")
+        try {
+            $resolvedGroup = Get-MgGroup -Filter "displayName eq '$escapedName'" -All -ErrorAction Stop | Select-Object -First 1
+        }
+        catch {
+            Write-NCMessage "Unable to resolve group '$GroupName': $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        if (-not $resolvedGroup) {
+            try {
+                $resolvedGroup = Get-MgGroup -GroupId $GroupName -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Entra group '$GroupName' not found by name or ID" -Level ERROR
+                return
+            }
+        }
+    }
+
+    try {
+        $members = @(Get-MgGroupMember -GroupId $resolvedGroup.Id -All -ErrorAction Stop)
+    }
+    catch {
+        Write-NCMessage "Unable to read members for group $($resolvedGroup.DisplayName): $($_.Exception.Message)" -Level ERROR
+        return
+    }
+
+    Add-EmptyLine
+    Write-Verbose "Group ($($resolvedGroup.DisplayName)) - Members found: $($members.Count)"
+
+    if (-not $members -or $members.Count -eq 0) {
+        Write-NCMessage "No members found for $($resolvedGroup.DisplayName)." -Level WARNING
+        return
+    }
+
+    $resolveType = {
+        param($odataType)
+        if ([string]::IsNullOrWhiteSpace($odataType)) {
+            return 'DirectoryObject'
+        }
+
+        $value = $odataType.ToLowerInvariant()
+        if ($value -match 'user') { return 'User' }
+        if ($value -match 'device') { return 'Device' }
+        if ($value -match 'group') { return 'Group' }
+        if ($value -match 'serviceprincipal') { return 'ServicePrincipal' }
+        if ($value -match 'orgcontact') { return 'Contact' }
+        return 'DirectoryObject'
+    }
+
+    $results = [System.Collections.Generic.List[object]]::new()
+    foreach ($member in $members) {
+        $props = if ($member.AdditionalProperties) { $member.AdditionalProperties } else { @{} }
+        $odataType = if ($props.ContainsKey('@odata.type')) { $props['@odata.type'] } else { $null }
+        $memberType = & $resolveType $odataType
+        $displayName = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
+        $upn = if ($props.ContainsKey('userPrincipalName')) { $props.userPrincipalName } else { $null }
+        $mail = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
+
+        $row = [ordered]@{
+            'Member Name' = if ($displayName) { $displayName } elseif ($upn) { $upn } else { $null }
+            'Member Type' = $memberType
+            'Member Id'   = $member.Id
+        }
+
+        if ($IncludeDeviceUsers.IsPresent -and $memberType -eq 'Device') {
+            $owners = @()
+            $users = @()
+            try {
+                $owners = @(Get-MgDeviceRegisteredOwner -DeviceId $member.Id -All -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to read registered owners for device $($displayName): $($_.Exception.Message)" -Level WARNING
+            }
+
+            try {
+                $users = @(Get-MgDeviceRegisteredUser -DeviceId $member.Id -All -ErrorAction Stop)
+            }
+            catch {
+                Write-NCMessage "Unable to read registered users for device $($displayName): $($_.Exception.Message)" -Level WARNING
+            }
+
+            $ownerLabels = $owners | ForEach-Object {
+                $ownerProps = if ($_.AdditionalProperties) { $_.AdditionalProperties } else { @{} }
+                if ($ownerProps.ContainsKey('userPrincipalName')) { $ownerProps.userPrincipalName } elseif ($ownerProps.ContainsKey('displayName')) { $ownerProps.displayName } else { $_.Id }
+            }
+            $userLabels = $users | ForEach-Object {
+                $userProps = if ($_.AdditionalProperties) { $_.AdditionalProperties } else { @{} }
+                if ($userProps.ContainsKey('userPrincipalName')) { $userProps.userPrincipalName } elseif ($userProps.ContainsKey('displayName')) { $userProps.displayName } else { $_.Id }
+            }
+
+            $ownerValue = if ($ownerLabels) { ($ownerLabels -join '; ') } else { $null }
+            $userValue = if ($userLabels) { ($userLabels -join '; ') } else { $null }
+            $combinedValue = $null
+
+            if ($ownerValue -and $userValue -and ($ownerValue -eq $userValue)) {
+                $combinedValue = $ownerValue
+            }
+            elseif ($ownerValue -and $userValue) {
+                $combinedValue = "Owners: $ownerValue | Users: $userValue"
+            }
+            elseif ($ownerValue) {
+                $combinedValue = "Owners: $ownerValue"
+            }
+            elseif ($userValue) {
+                $combinedValue = "Users: $userValue"
+            }
+
+            $row['Device Owners/Users'] = $combinedValue
+        }
+
+        if ($GridView.IsPresent) {
+            $row['Member UPN'] = $upn
+            $row['Member Mail'] = $mail
+            $row['Member OData Type'] = $odataType
+        }
+
+        $results.Add([pscustomobject]$row) | Out-Null
+    }
+
+    $sorted = $results | Sort-Object 'Member Type', 'Member Name'
+    if ($GridView.IsPresent) {
+        $sorted | Out-GridView -Title "Entra Group Members - $($resolvedGroup.DisplayName)"
+    }
+    else {
+        $sorted
+    }
+}
+
+function Get-EntraGroupUser {
+    <#
+    .SYNOPSIS
+        Shows the Entra groups that a user belongs to.
+    .DESCRIPTION
+        Connects to Microsoft Graph, resolves the target user by UPN/display name or ID, then
+        lists every directory object membership for that user.
+    .PARAMETER UserIdentifier
+        User principal name, display name, or object ID. Accepts pipeline input and common Id/DisplayName property names.
+    .PARAMETER TreatInputAsId
+        Treat the provided UserIdentifier as an object ID without attempting name resolution.
+    .PARAMETER GridView
+        Show additional details in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Get-EntraGroupUser -UserIdentifier "user@contoso.com"
+    .EXAMPLE
+        "00000000-0000-0000-0000-000000000000" | Get-EntraGroupUser -TreatInputAsId -GridView
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'UPN', 'Mail', 'Id', 'UserId', 'DisplayName', 'Identity')]
+        [string]$UserIdentifier,
+        [switch]$TreatInputAsId,
+        [switch]$GridView
+    )
+
+    begin {
+        $graphConnected = $null
+    }
+
+    process {
+        if ($null -eq $graphConnected) {
+            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+            if (-not $graphConnected) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+        }
+
+        $user = $null
+        $userLabel = $UserIdentifier
+
+        if ($TreatInputAsId.IsPresent -or $UserIdentifier -match '^[0-9a-fA-F-]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+            try {
+                $user = Get-MgUser -UserId $UserIdentifier -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Entra user with ID '$UserIdentifier' not found: $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+        else {
+            try {
+                $user = Get-MgUser -UserId $UserIdentifier -ErrorAction Stop
+            }
+            catch {
+                $resolvedIdentifier = Find-UserRecipient -UserPrincipalName $UserIdentifier
+                if ($resolvedIdentifier) {
+                    try {
+                        $user = Get-MgUser -UserId $resolvedIdentifier -ErrorAction Stop
+                    }
+                    catch {
+                        Write-NCMessage "Unable to resolve user '$UserIdentifier': $($_.Exception.Message)" -Level ERROR
+                        return
+                    }
+                }
+
+                if ($user) {
+                    $userLabel = if ($user.UserPrincipalName) { $user.UserPrincipalName } else { $user.DisplayName }
+                }
+                else {
+                    $escapedUser = $UserIdentifier.Replace("'", "''")
+                    try {
+                        $userMatches = Get-MgUser -Filter "displayName eq '$escapedUser'" -All -ErrorAction Stop
+                    }
+                    catch {
+                        Write-NCMessage "Unable to resolve user '$UserIdentifier': $($_.Exception.Message)" -Level ERROR
+                        return
+                    }
+
+                    if (-not $userMatches -or $userMatches.Count -eq 0) {
+                        Write-NCMessage "User '$UserIdentifier' not found" -Level WARNING
+                        return
+                    }
+
+                    if ($userMatches.Count -gt 1) {
+                        Write-NCMessage "Multiple users matched '$UserIdentifier'. Using the first result ($($userMatches[0].UserPrincipalName))." -Level WARNING
+                    }
+
+                    $user = $userMatches | Select-Object -First 1
+                }
+            }
+        }
+
+        if (-not $user) {
+            return
+        }
+
+        $userLabel = if ($user.UserPrincipalName) { $user.UserPrincipalName } else { $user.DisplayName }
+
+        try {
+            $memberships = @(Get-MgUserMemberOf -UserId $user.Id -All -ErrorAction Stop)
+        }
+        catch {
+            Write-NCMessage "Unable to read group memberships for user ${userLabel}: $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        Add-EmptyLine
+        Write-Verbose "User ($userLabel) - Groups found: $($memberships.Count)"
+
+        if (-not $memberships -or $memberships.Count -eq 0) {
+            Write-NCMessage "No groups found for $userLabel." -Level WARNING
+            return
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        foreach ($membership in $memberships) {
+            $props = if ($membership.AdditionalProperties) { $membership.AdditionalProperties } else { @{} }
+            $row = [ordered]@{
+                'Group Name' = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
+                'Group Mail' = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
+            }
+
+            if ($GridView.IsPresent) {
+                $row['Group Description'] = if ($props.ContainsKey('description')) { $props.description } else { $null }
+                $row['Group Mail Nickname'] = if ($props.ContainsKey('mailNickname')) { $props.mailNickname } else { $null }
+                $row['Group Mail Enabled'] = if ($props.ContainsKey('mailEnabled')) { $props.mailEnabled } else { $null }
+                $row['Group Type'] = if ($props.ContainsKey('groupTypes')) { ($props.groupTypes -join ', ') } else { $null }
+                $row['Group ID'] = $membership.Id
+            }
+
+            $results.Add([pscustomobject]$row) | Out-Null
+        }
+
+        if ($GridView.IsPresent) {
+            $results | Out-GridView -Title "Entra User Groups - $userLabel"
+        }
+        else {
+            $results | Sort-Object 'Group Name'
+        }
+    }
+}
+
 function Get-RoleGroupsMembers {
     <#
     .SYNOPSIS
@@ -1835,684 +3247,96 @@ function Get-UserGroups {
     }
 }
 
-function Get-EntraGroupDevice {
+function New-EntraSecurityGroup {
     <#
     .SYNOPSIS
-        Shows the Entra groups that a device belongs to.
+        Creates a new Entra security group.
     .DESCRIPTION
-        Connects to Microsoft Graph, resolves the target device by display name or ID, then
-        lists every directory object membership for that device.
-    .PARAMETER DeviceIdentifier
-        Device display name or object ID. Accepts pipeline input and common Id/DisplayName property names.
-    .PARAMETER TreatInputAsId
-        Treat the provided DeviceIdentifier as an object ID without attempting name resolution.
-    .PARAMETER GridView
-        Show additional details in Out-GridView instead of returning objects.
-    .EXAMPLE
-        Get-EntraGroupDevice -DeviceIdentifier "PC123"
-    .EXAMPLE
-        "00000000-0000-0000-0000-000000000000" | Get-EntraGroupDevice -TreatInputAsId -GridView
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('Device', 'DeviceName', 'Id', 'DeviceId', 'Name', 'Identity', 'DisplayName')]
-        [string]$DeviceIdentifier,
-        [switch]$TreatInputAsId,
-        [switch]$GridView
-    )
-
-    begin {
-        $graphConnected = $null
-    }
-
-    process {
-        if ($null -eq $graphConnected) {
-            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-            if (-not $graphConnected) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-        }
-
-        $device = $null
-        $deviceLabel = $DeviceIdentifier
-
-        if ($TreatInputAsId.IsPresent -or $DeviceIdentifier -match '^[0-9a-fA-F-]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
-            try {
-                $device = Get-MgDevice -DeviceId $DeviceIdentifier -ErrorAction Stop
-            }
-            catch {
-                Write-NCMessage "Entra device with ID '$DeviceIdentifier' not found: $($_.Exception.Message)" -Level ERROR
-                return
-            }
-        }
-        else {
-            $escapedDevice = $DeviceIdentifier.Replace("'", "''")
-            try {
-                $deviceMatches = Get-MgDevice -Filter "displayName eq '$escapedDevice'" -All -ErrorAction Stop
-            }
-            catch {
-                Write-NCMessage "Unable to resolve device '$DeviceIdentifier': $($_.Exception.Message)" -Level ERROR
-                return
-            }
-
-            if (-not $deviceMatches -or $deviceMatches.Count -eq 0) {
-                Write-NCMessage "Device '$DeviceIdentifier' not found" -Level WARNING
-                return
-            }
-
-            if ($deviceMatches.Count -gt 1) {
-                Write-NCMessage "Multiple devices matched '$DeviceIdentifier'. Using the first result ($($deviceMatches[0].DisplayName))" -Level WARNING
-            }
-
-            $device = $deviceMatches | Select-Object -First 1
-            $deviceLabel = $device.DisplayName
-        }
-
-        if (-not $device) {
-            return
-        }
-
-        try {
-            $memberships = @(Get-MgDeviceMemberOf -DeviceId $device.Id -All -ErrorAction Stop)
-        }
-        catch {
-            Write-NCMessage "Unable to read group memberships for device ${deviceLabel}: $($_.Exception.Message)" -Level ERROR
-            return
-        }
-
-        Add-EmptyLine
-        Write-Verbose "Device ($deviceLabel) - Groups found: $($memberships.Count)"
-
-        if (-not $memberships -or $memberships.Count -eq 0) {
-            Write-NCMessage "No groups found for $deviceLabel." -Level WARNING
-            return
-        }
-
-        $results = [System.Collections.Generic.List[object]]::new()
-        foreach ($membership in $memberships) {
-            $props = if ($membership.AdditionalProperties) { $membership.AdditionalProperties } else { @{} }
-            $row = [ordered]@{
-                'Group Name' = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
-                'Group Mail' = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
-            }
-
-            if ($GridView.IsPresent) {
-                $row['Group Description'] = if ($props.ContainsKey('description')) { $props.description } else { $null }
-                $row['Group Mail Nickname'] = if ($props.ContainsKey('mailNickname')) { $props.mailNickname } else { $null }
-                $row['Group Mail Enabled'] = if ($props.ContainsKey('mailEnabled')) { $props.mailEnabled } else { $null }
-                $row['Group Type'] = if ($props.ContainsKey('groupTypes')) { ($props.groupTypes -join ', ') } else { $null }
-                $row['Group ID'] = $membership.Id
-            }
-
-            $results.Add([pscustomobject]$row) | Out-Null
-        }
-
-        if ($GridView.IsPresent) {
-            $results | Out-GridView -Title "Entra Device Groups - $deviceLabel"
-        }
-        else {
-            $results | Sort-Object 'Group Name'
-        }
-    }
-}
-
-function Search-EntraGroup {
-    <#
-    .SYNOPSIS
-        Finds Entra groups by display name or description.
-    .DESCRIPTION
-        Uses Microsoft Graph search to find groups by display name or description and returns
-        key properties for easy identification.
-    .PARAMETER SearchText
-        Text to search for in display name and/or description. Accepts pipeline input.
-    .PARAMETER SearchIn
-        Where to search: DisplayName, Description, or Any (both).
-    .PARAMETER GridView
-        Show additional details in Out-GridView instead of returning objects.
-    .EXAMPLE
-        Search-EntraGroup -SearchText "java"
-    .EXAMPLE
-        Search-EntraGroup -SearchText "legacy apps" -SearchIn Description
-    .EXAMPLE
-        "marketing" | Search-EntraGroup -SearchIn Any -GridView
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Position = 0)]
-        [Alias('Search', 'Query', 'Text', 'Name', 'DisplayName', 'Description')]
-        [string]$SearchText,
-
-        [ValidateSet('DisplayName', 'Description', 'Any')]
-        [string]$SearchIn = 'DisplayName',
-
-        [switch]$GridView
-    )
-
-    begin {
-        $graphConnected = $null
-    }
-
-    process {
-        if ($null -eq $graphConnected) {
-            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-            if (-not $graphConnected) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-        }
-
-        if ([string]::IsNullOrWhiteSpace($SearchText)) {
-            Write-NCMessage "SearchText cannot be empty." -Level WARNING
-            return
-        }
-
-        $escapedText = $SearchText.Replace('"', '""').Trim()
-        if ([string]::IsNullOrWhiteSpace($escapedText)) {
-            Write-NCMessage "SearchText cannot be empty." -Level WARNING
-            return
-        }
-
-        $groups = @()
-
-        try {
-            switch ($SearchIn) {
-                'DisplayName' {
-                    $searchClause = "`"displayName:$escapedText`""
-                    $groups = @(Get-MgGroup -Search $searchClause -ConsistencyLevel eventual -CountVariable count -All -ErrorAction Stop)
-                }
-                'Description' {
-                    $searchClause = "`"description:$escapedText`""
-                    $groups = @(Get-MgGroup -Search $searchClause -ConsistencyLevel eventual -CountVariable count -All -ErrorAction Stop)
-                }
-                'Any' {
-                    $searchDisplay = "`"displayName:$escapedText`""
-                    $searchDescription = "`"description:$escapedText`""
-                    $byName = @(Get-MgGroup -Search $searchDisplay -ConsistencyLevel eventual -CountVariable countName -All -ErrorAction Stop)
-                    $byDescription = @(Get-MgGroup -Search $searchDescription -ConsistencyLevel eventual -CountVariable countDesc -All -ErrorAction Stop)
-                    $groups = @($byName + $byDescription | Sort-Object Id -Unique)
-                }
-            }
-        }
-        catch {
-            Write-NCMessage "Unable to search groups with '$SearchText': $($_.Exception.Message)" -Level ERROR
-            return
-        }
-
-        Add-EmptyLine
-        Write-Verbose "Groups found: $($groups.Count) for '$SearchText'."
-
-        if (-not $groups -or $groups.Count -eq 0) {
-            Write-NCMessage "No groups found for '$SearchText'." -Level WARNING
-            return
-        }
-
-        $results = [System.Collections.Generic.List[object]]::new()
-        foreach ($group in $groups) {
-            $row = [ordered]@{
-                'Group Name'        = $group.DisplayName
-                'Group Id'          = $group.Id
-                'Group Description' = $group.Description
-            }
-
-            if ($GridView.IsPresent) {
-                $row['Group Mail Nickname'] = $group.MailNickname
-                $row['Group Mail Enabled'] = $group.MailEnabled
-                $row['Group Security Enabled'] = $group.SecurityEnabled
-                $row['Group Types'] = if ($group.GroupTypes) { ($group.GroupTypes -join ', ') } else { $null }
-            }
-
-            $results.Add([pscustomobject]$row) | Out-Null
-        }
-
-        if ($GridView.IsPresent) {
-            $results | Out-GridView -Title "Entra Groups - Search: $SearchText"
-        }
-        else {
-            $results | Sort-Object 'Group Name'
-        }
-    }
-}
-
-function Export-EmptyEntraGroups {
-    <#
-    .SYNOPSIS
-        Exports Entra groups that have no members.
-    .DESCRIPTION
-        Connects to Microsoft Graph, enumerates groups, checks membership for each one, and exports
-        the groups with zero members to CSV by default.
-    .PARAMETER CsvFolder
-        Destination folder for the CSV file when exporting the report.
-    .PARAMETER Csv
-        When present, export the report to CSV. Defaults to on.
-    .EXAMPLE
-        Export-EmptyEntraGroups
-    .EXAMPLE
-        Export-EmptyEntraGroups -CsvFolder 'C:\Reports\Groups'
-    #>
-    [CmdletBinding()]
-    param(
-        [string]$CsvFolder,
-        [bool]$Csv = $true
-    )
-
-    begin {
-        Set-ProgressAndInfoPreferences
-        $report = [System.Collections.Generic.List[object]]::new()
-    }
-
-    process {
-        try {
-            if (-not (Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false)) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-
-            $groups = @(Get-MgGroup -All -ErrorAction Stop)
-            if (-not $groups -or $groups.Count -eq 0) {
-                Write-NCMessage "No Entra groups found." -Level WARNING
-                return
-            }
-
-            $totalGroups = $groups.Count
-            $processedCount = 0
-
-            foreach ($group in $groups) {
-                $processedCount++
-                $Percentage = Get-NCProgressPercent -Current $counter -Total $totalGroups
-                Write-Progress -Activity "Checking $($group.DisplayName)" -Status "$processedCount of $totalGroups - $Percentage%" -PercentComplete $Percentage
-
-                try {
-                    $members = @(Get-MgGroupMember -GroupId $group.Id -All -ErrorAction Stop)
-                }
-                catch {
-                    Write-NCMessage "Unable to read members for group '$($group.DisplayName)'. $($_.Exception.Message)" -Level WARNING
-                    continue
-                }
-
-                if ($members.Count -gt 0) {
-                    continue
-                }
-
-                $groupType = if ($group.GroupTypes -contains 'Unified' -and $group.SecurityEnabled) {
-                    'Microsoft 365 (security-enabled)'
-                }
-                elseif ($group.GroupTypes -contains 'Unified' -and -not $group.SecurityEnabled) {
-                    'Microsoft 365'
-                }
-                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled -and $group.MailEnabled) {
-                    'Mail-enabled security'
-                }
-                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.SecurityEnabled) {
-                    'Security'
-                }
-                elseif (-not ($group.GroupTypes -contains 'Unified') -and $group.MailEnabled) {
-                    'Distribution'
-                }
-                else {
-                    'N/A'
-                }
-
-                $report.Add([pscustomobject][ordered]@{
-                        DisplayName     = $group.DisplayName
-                        Id              = $group.Id
-                        GroupType       = $groupType
-                        MemberCount     = 0
-                        MailEnabled     = $group.MailEnabled
-                        SecurityEnabled = $group.SecurityEnabled
-                    }) | Out-Null
-            }
-
-            if ($Csv) {
-                $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
-                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-EmptyGroups.csv"
-                $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-                Write-NCMessage "Empty groups report exported to $csvPath." -Level SUCCESS
-            }
-            else {
-                $report | Sort-Object DisplayName
-            }
-        }
-        catch {
-            Write-NCMessage "Unable to export empty Entra groups. $($_.Exception.Message)" -Level ERROR
-        }
-        finally {
-            Write-Progress -Activity "Checking empty Entra groups" -Completed
-            Restore-ProgressAndInfoPreferences
-        }
-    }
-}
-
-function Get-EntraGroupUser {
-    <#
-    .SYNOPSIS
-        Shows the Entra groups that a user belongs to.
-    .DESCRIPTION
-        Connects to Microsoft Graph, resolves the target user by UPN/display name or ID, then
-        lists every directory object membership for that user.
-    .PARAMETER UserIdentifier
-        User principal name, display name, or object ID. Accepts pipeline input and common Id/DisplayName property names.
-    .PARAMETER TreatInputAsId
-        Treat the provided UserIdentifier as an object ID without attempting name resolution.
-    .PARAMETER GridView
-        Show additional details in Out-GridView instead of returning objects.
-    .EXAMPLE
-        Get-EntraGroupUser -UserIdentifier "user@contoso.com"
-    .EXAMPLE
-        "00000000-0000-0000-0000-000000000000" | Get-EntraGroupUser -TreatInputAsId -GridView
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('User', 'UPN', 'Mail', 'Id', 'UserId', 'DisplayName', 'Identity')]
-        [string]$UserIdentifier,
-        [switch]$TreatInputAsId,
-        [switch]$GridView
-    )
-
-    begin {
-        $graphConnected = $null
-    }
-
-    process {
-        if ($null -eq $graphConnected) {
-            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
-            if (-not $graphConnected) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-        }
-
-        $user = $null
-        $userLabel = $UserIdentifier
-
-        if ($TreatInputAsId.IsPresent -or $UserIdentifier -match '^[0-9a-fA-F-]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
-            try {
-                $user = Get-MgUser -UserId $UserIdentifier -ErrorAction Stop
-            }
-            catch {
-                Write-NCMessage "Entra user with ID '$UserIdentifier' not found: $($_.Exception.Message)" -Level ERROR
-                return
-            }
-        }
-        else {
-            try {
-                $user = Get-MgUser -UserId $UserIdentifier -ErrorAction Stop
-            }
-            catch {
-                $resolvedIdentifier = Find-UserRecipient -UserPrincipalName $UserIdentifier
-                if ($resolvedIdentifier) {
-                    try {
-                        $user = Get-MgUser -UserId $resolvedIdentifier -ErrorAction Stop
-                    }
-                    catch {
-                        Write-NCMessage "Unable to resolve user '$UserIdentifier': $($_.Exception.Message)" -Level ERROR
-                        return
-                    }
-                }
-
-                if ($user) {
-                    $userLabel = if ($user.UserPrincipalName) { $user.UserPrincipalName } else { $user.DisplayName }
-                }
-                else {
-                    $escapedUser = $UserIdentifier.Replace("'", "''")
-                    try {
-                        $userMatches = Get-MgUser -Filter "displayName eq '$escapedUser'" -All -ErrorAction Stop
-                    }
-                    catch {
-                        Write-NCMessage "Unable to resolve user '$UserIdentifier': $($_.Exception.Message)" -Level ERROR
-                        return
-                    }
-
-                    if (-not $userMatches -or $userMatches.Count -eq 0) {
-                        Write-NCMessage "User '$UserIdentifier' not found" -Level WARNING
-                        return
-                    }
-
-                    if ($userMatches.Count -gt 1) {
-                        Write-NCMessage "Multiple users matched '$UserIdentifier'. Using the first result ($($userMatches[0].UserPrincipalName))." -Level WARNING
-                    }
-
-                    $user = $userMatches | Select-Object -First 1
-                }
-            }
-        }
-
-        if (-not $user) {
-            return
-        }
-
-        $userLabel = if ($user.UserPrincipalName) { $user.UserPrincipalName } else { $user.DisplayName }
-
-        try {
-            $memberships = @(Get-MgUserMemberOf -UserId $user.Id -All -ErrorAction Stop)
-        }
-        catch {
-            Write-NCMessage "Unable to read group memberships for user ${userLabel}: $($_.Exception.Message)" -Level ERROR
-            return
-        }
-
-        Add-EmptyLine
-        Write-Verbose "User ($userLabel) - Groups found: $($memberships.Count)"
-
-        if (-not $memberships -or $memberships.Count -eq 0) {
-            Write-NCMessage "No groups found for $userLabel." -Level WARNING
-            return
-        }
-
-        $results = [System.Collections.Generic.List[object]]::new()
-        foreach ($membership in $memberships) {
-            $props = if ($membership.AdditionalProperties) { $membership.AdditionalProperties } else { @{} }
-            $row = [ordered]@{
-                'Group Name' = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
-                'Group Mail' = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
-            }
-
-            if ($GridView.IsPresent) {
-                $row['Group Description'] = if ($props.ContainsKey('description')) { $props.description } else { $null }
-                $row['Group Mail Nickname'] = if ($props.ContainsKey('mailNickname')) { $props.mailNickname } else { $null }
-                $row['Group Mail Enabled'] = if ($props.ContainsKey('mailEnabled')) { $props.mailEnabled } else { $null }
-                $row['Group Type'] = if ($props.ContainsKey('groupTypes')) { ($props.groupTypes -join ', ') } else { $null }
-                $row['Group ID'] = $membership.Id
-            }
-
-            $results.Add([pscustomobject]$row) | Out-Null
-        }
-
-        if ($GridView.IsPresent) {
-            $results | Out-GridView -Title "Entra User Groups - $userLabel"
-        }
-        else {
-            $results | Sort-Object 'Group Name'
-        }
-    }
-}
-
-function Get-EntraGroupMembers {
-    <#
-    .SYNOPSIS
-        Shows the members of an Entra group (users, devices, and other directory objects).
-    .DESCRIPTION
-        Connects to Microsoft Graph, resolves the target group by display name or ID, then
-        lists every member of that group regardless of type.
+        Connects to Microsoft Graph and creates a security-enabled, mail-disabled group. The
+        mail nickname is generated automatically from the display name unless overridden.
     .PARAMETER GroupName
-        Display name of the Entra group.
-    .PARAMETER GroupId
-        Object ID of the Entra group.
-    .PARAMETER IncludeDeviceUsers
-        When members are devices, resolve registered owners and users (may require additional Graph calls).
-    .PARAMETER GridView
-        Show additional details in Out-GridView instead of returning objects.
+        Display name of the new Entra security group.
+    .PARAMETER Description
+        Optional group description.
+    .PARAMETER MailNickname
+        Optional mail nickname. When omitted, a sanitized value is generated from GroupName.
+    .PARAMETER PassThru
+        Emit the created group object.
     .EXAMPLE
-        Get-EntraGroupMembers -GroupName "My Entra Group"
+        New-EntraSecurityGroup -GroupName "Sec - Finance"
     .EXAMPLE
-        Get-EntraGroupMembers -GroupId "00000000-0000-0000-0000-000000000000" -GridView
-    .EXAMPLE
-        "My Entra Group" | Get-EntraGroupMembers
+        New-EntraSecurityGroup -GroupName "Sec - Finance" -Description "Finance security group"
     #>
-    [CmdletBinding(DefaultParameterSetName = 'ByName')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('Group', 'DisplayName', 'Name', 'Identity')]
+        [Parameter(Mandatory = $true, Position = 0)]
+        [Alias('DisplayName', 'Name')]
         [string]$GroupName,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
-        [string]$GroupId,
-
-        [switch]$IncludeDeviceUsers,
-        [switch]$GridView
+        [string]$Description,
+        [string]$MailNickname,
+        [switch]$PassThru
     )
 
-    $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+    $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
     if (-not $graphConnected) {
         Add-EmptyLine
         Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
         return
     }
 
-    $resolvedGroup = $null
-    if ($PSCmdlet.ParameterSetName -eq 'ById') {
-        try {
-            $resolvedGroup = Get-MgGroup -GroupId $GroupId -ErrorAction Stop
-        }
-        catch {
-            Write-NCMessage "Entra group with ID '$GroupId' not found: $($_.Exception.Message)" -Level ERROR
-            return
-        }
+    if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+        Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($GroupName)) {
+        Write-NCMessage "GroupName cannot be empty." -Level WARNING
+        return
+    }
+
+    $sanitizedNickname = if ([string]::IsNullOrWhiteSpace($MailNickname)) {
+        [regex]::Replace($GroupName, '[^a-zA-Z0-9]', '')
     }
     else {
-        $escapedName = $GroupName.Replace("'", "''")
-        try {
-            $resolvedGroup = Get-MgGroup -Filter "displayName eq '$escapedName'" -All -ErrorAction Stop | Select-Object -First 1
-        }
-        catch {
-            Write-NCMessage "Unable to resolve group '$GroupName': $($_.Exception.Message)" -Level ERROR
-            return
-        }
+        $MailNickname.Trim()
+    }
 
-        if (-not $resolvedGroup) {
-            try {
-                $resolvedGroup = Get-MgGroup -GroupId $GroupName -ErrorAction Stop
-            }
-            catch {
-                Write-NCMessage "Entra group '$GroupName' not found by name or ID" -Level ERROR
-                return
-            }
-        }
+    if ([string]::IsNullOrWhiteSpace($sanitizedNickname)) {
+        $sanitizedNickname = "group$((Get-Date).ToString('yyyyMMddHHmmss'))"
+    }
+
+    $groupBody = @{
+        displayName     = $GroupName
+        mailEnabled     = $false
+        mailNickname    = $sanitizedNickname
+        securityEnabled = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Description)) {
+        $groupBody.description = $Description
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($GroupName, 'Create security group')) {
+        return
     }
 
     try {
-        $members = @(Get-MgGroupMember -GroupId $resolvedGroup.Id -All -ErrorAction Stop)
+        $createdGroup = Invoke-MgGraphRequest -Uri 'https://graph.microsoft.com/v1.0/groups' -Method POST -Body ($groupBody | ConvertTo-Json -Depth 10) -ContentType 'application/json'
+        Write-NCMessage "Created security group '$GroupName'." -Level SUCCESS
+
+        if ($PassThru.IsPresent) {
+            [pscustomobject]@{
+                GroupName       = $createdGroup.displayName
+                GroupId         = $createdGroup.id
+                MailNickname    = $createdGroup.mailNickname
+                Description     = $createdGroup.description
+                SecurityEnabled = $createdGroup.securityEnabled
+                MailEnabled     = $createdGroup.mailEnabled
+            }
+        }
     }
     catch {
-        Write-NCMessage "Unable to read members for group $($resolvedGroup.DisplayName): $($_.Exception.Message)" -Level ERROR
-        return
-    }
-
-    Add-EmptyLine
-    Write-Verbose "Group ($($resolvedGroup.DisplayName)) - Members found: $($members.Count)"
-
-    if (-not $members -or $members.Count -eq 0) {
-        Write-NCMessage "No members found for $($resolvedGroup.DisplayName)." -Level WARNING
-        return
-    }
-
-    $resolveType = {
-        param($odataType)
-        if ([string]::IsNullOrWhiteSpace($odataType)) {
-            return 'DirectoryObject'
-        }
-
-        $value = $odataType.ToLowerInvariant()
-        if ($value -match 'user') { return 'User' }
-        if ($value -match 'device') { return 'Device' }
-        if ($value -match 'group') { return 'Group' }
-        if ($value -match 'serviceprincipal') { return 'ServicePrincipal' }
-        if ($value -match 'orgcontact') { return 'Contact' }
-        return 'DirectoryObject'
-    }
-
-    $results = [System.Collections.Generic.List[object]]::new()
-    foreach ($member in $members) {
-        $props = if ($member.AdditionalProperties) { $member.AdditionalProperties } else { @{} }
-        $odataType = if ($props.ContainsKey('@odata.type')) { $props['@odata.type'] } else { $null }
-        $memberType = & $resolveType $odataType
-        $displayName = if ($props.ContainsKey('displayName')) { $props.displayName } else { $null }
-        $upn = if ($props.ContainsKey('userPrincipalName')) { $props.userPrincipalName } else { $null }
-        $mail = if ($props.ContainsKey('mail')) { $props.mail } else { $null }
-
-        $row = [ordered]@{
-            'Member Name' = if ($displayName) { $displayName } elseif ($upn) { $upn } else { $null }
-            'Member Type' = $memberType
-            'Member Id'   = $member.Id
-        }
-
-        if ($IncludeDeviceUsers.IsPresent -and $memberType -eq 'Device') {
-            $owners = @()
-            $users = @()
-            try {
-                $owners = @(Get-MgDeviceRegisteredOwner -DeviceId $member.Id -All -ErrorAction Stop)
-            }
-            catch {
-                Write-NCMessage "Unable to read registered owners for device $($displayName): $($_.Exception.Message)" -Level WARNING
-            }
-
-            try {
-                $users = @(Get-MgDeviceRegisteredUser -DeviceId $member.Id -All -ErrorAction Stop)
-            }
-            catch {
-                Write-NCMessage "Unable to read registered users for device $($displayName): $($_.Exception.Message)" -Level WARNING
-            }
-
-            $ownerLabels = $owners | ForEach-Object {
-                $ownerProps = if ($_.AdditionalProperties) { $_.AdditionalProperties } else { @{} }
-                if ($ownerProps.ContainsKey('userPrincipalName')) { $ownerProps.userPrincipalName } elseif ($ownerProps.ContainsKey('displayName')) { $ownerProps.displayName } else { $_.Id }
-            }
-            $userLabels = $users | ForEach-Object {
-                $userProps = if ($_.AdditionalProperties) { $_.AdditionalProperties } else { @{} }
-                if ($userProps.ContainsKey('userPrincipalName')) { $userProps.userPrincipalName } elseif ($userProps.ContainsKey('displayName')) { $userProps.displayName } else { $_.Id }
-            }
-
-            $ownerValue = if ($ownerLabels) { ($ownerLabels -join '; ') } else { $null }
-            $userValue = if ($userLabels) { ($userLabels -join '; ') } else { $null }
-            $combinedValue = $null
-
-            if ($ownerValue -and $userValue -and ($ownerValue -eq $userValue)) {
-                $combinedValue = $ownerValue
-            }
-            elseif ($ownerValue -and $userValue) {
-                $combinedValue = "Owners: $ownerValue | Users: $userValue"
-            }
-            elseif ($ownerValue) {
-                $combinedValue = "Owners: $ownerValue"
-            }
-            elseif ($userValue) {
-                $combinedValue = "Users: $userValue"
-            }
-
-            $row['Device Owners/Users'] = $combinedValue
-        }
-
-        if ($GridView.IsPresent) {
-            $row['Member UPN'] = $upn
-            $row['Member Mail'] = $mail
-            $row['Member OData Type'] = $odataType
-        }
-
-        $results.Add([pscustomobject]$row) | Out-Null
-    }
-
-    $sorted = $results | Sort-Object 'Member Type', 'Member Name'
-    if ($GridView.IsPresent) {
-        $sorted | Out-GridView -Title "Entra Group Members - $($resolvedGroup.DisplayName)"
-    }
-    else {
-        $sorted
+        Write-NCMessage "Failed to create security group '$GroupName': $($_.Exception.Message)" -Level ERROR
     }
 }
 
@@ -3037,4 +3861,322 @@ function Remove-EntraGroupUser {
     }
 }
 
+function Search-EntraGroup {
+    <#
+    .SYNOPSIS
+        Finds Entra groups by display name or description.
+    .DESCRIPTION
+        Uses Microsoft Graph search to find groups by display name or description and returns
+        key properties for easy identification.
+    .PARAMETER SearchText
+        Text to search for in display name and/or description. Accepts pipeline input.
+    .PARAMETER SearchIn
+        Where to search: DisplayName, Description, or Any (both).
+    .PARAMETER GridView
+        Show additional details in Out-GridView instead of returning objects.
+    .EXAMPLE
+        Search-EntraGroup -SearchText "java"
+    .EXAMPLE
+        Search-EntraGroup -SearchText "legacy apps" -SearchIn Description
+    .EXAMPLE
+        "marketing" | Search-EntraGroup -SearchIn Any -GridView
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Position = 0)]
+        [Alias('Search', 'Query', 'Text', 'Name', 'DisplayName', 'Description')]
+        [string]$SearchText,
 
+        [ValidateSet('DisplayName', 'Description', 'Any')]
+        [string]$SearchIn = 'DisplayName',
+
+        [switch]$GridView
+    )
+
+    begin {
+        $graphConnected = $null
+    }
+
+    process {
+        if ($null -eq $graphConnected) {
+            $graphConnected = Test-MgGraphConnection -Scopes @('Group.Read.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+            if (-not $graphConnected) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($SearchText)) {
+            Write-NCMessage "SearchText cannot be empty." -Level WARNING
+            return
+        }
+
+        $escapedText = $SearchText.Replace('"', '""').Trim()
+        if ([string]::IsNullOrWhiteSpace($escapedText)) {
+            Write-NCMessage "SearchText cannot be empty." -Level WARNING
+            return
+        }
+
+        $groups = @()
+
+        try {
+            switch ($SearchIn) {
+                'DisplayName' {
+                    $searchClause = "`"displayName:$escapedText`""
+                    $groups = @(Get-MgGroup -Search $searchClause -ConsistencyLevel eventual -CountVariable count -All -ErrorAction Stop)
+                }
+                'Description' {
+                    $searchClause = "`"description:$escapedText`""
+                    $groups = @(Get-MgGroup -Search $searchClause -ConsistencyLevel eventual -CountVariable count -All -ErrorAction Stop)
+                }
+                'Any' {
+                    $searchDisplay = "`"displayName:$escapedText`""
+                    $searchDescription = "`"description:$escapedText`""
+                    $byName = @(Get-MgGroup -Search $searchDisplay -ConsistencyLevel eventual -CountVariable countName -All -ErrorAction Stop)
+                    $byDescription = @(Get-MgGroup -Search $searchDescription -ConsistencyLevel eventual -CountVariable countDesc -All -ErrorAction Stop)
+                    $groups = @($byName + $byDescription | Sort-Object Id -Unique)
+                }
+            }
+        }
+        catch {
+            Write-NCMessage "Unable to search groups with '$SearchText': $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        Add-EmptyLine
+        Write-Verbose "Groups found: $($groups.Count) for '$SearchText'."
+
+        if (-not $groups -or $groups.Count -eq 0) {
+            Write-NCMessage "No groups found for '$SearchText'." -Level WARNING
+            return
+        }
+
+        $results = [System.Collections.Generic.List[object]]::new()
+        foreach ($group in $groups) {
+            $row = [ordered]@{
+                'Group Name'        = $group.DisplayName
+                'Group Id'          = $group.Id
+                'Group Description' = $group.Description
+            }
+
+            if ($GridView.IsPresent) {
+                $row['Group Mail Nickname'] = $group.MailNickname
+                $row['Group Mail Enabled'] = $group.MailEnabled
+                $row['Group Security Enabled'] = $group.SecurityEnabled
+                $row['Group Types'] = if ($group.GroupTypes) { ($group.GroupTypes -join ', ') } else { $null }
+            }
+
+            $results.Add([pscustomobject]$row) | Out-Null
+        }
+
+        if ($GridView.IsPresent) {
+            $results | Out-GridView -Title "Entra Groups - Search: $SearchText"
+        }
+        else {
+            $results | Sort-Object 'Group Name'
+        }
+    }
+}
+
+function Set-EntraGroupDescription {
+    <#
+    .SYNOPSIS
+        Updates the description of an Entra group.
+    .DESCRIPTION
+        Resolves an Entra group by display name or object ID and updates only the description
+        property in Microsoft Graph.
+    .PARAMETER GroupName
+        Display name of the target Entra group.
+    .PARAMETER GroupId
+        Object ID of the target Entra group.
+    .PARAMETER Description
+        New group description. Pass an empty string to clear the description.
+    .PARAMETER PassThru
+        Emit the updated group object.
+    .EXAMPLE
+        Set-EntraGroupDescription -GroupName "GitLab-Prod" -Description "Production GitLab access group"
+    .EXAMPLE
+        Set-EntraGroupDescription -GroupId "00000000-0000-0000-0000-000000000000" -Description "" -PassThru
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0)]
+        [Alias('DisplayName', 'Name')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [string]$GroupId,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [AllowEmptyString()]
+        [string]$Description,
+
+        [switch]$PassThru
+    )
+
+    $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+    if (-not $graphConnected) {
+        Add-EmptyLine
+        Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        return
+    }
+
+    if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+        Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+        return
+    }
+
+    $resolvedGroup = if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        Resolve-NCEntraGroup -GroupName $GroupId -GroupId $GroupId
+    }
+    else {
+        Resolve-NCEntraGroup -GroupName $GroupName
+    }
+
+    if (-not $resolvedGroup) {
+        return
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($resolvedGroup.DisplayName, 'Update group description')) {
+        return
+    }
+
+    try {
+        Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($resolvedGroup.Id)" -Method PATCH -Body (@{ description = $Description } | ConvertTo-Json -Depth 10) -ContentType 'application/json' | Out-Null
+        Write-NCMessage "Updated description for group '$($resolvedGroup.DisplayName)'." -Level SUCCESS
+
+        if ($PassThru.IsPresent) {
+            Get-MgGroup -GroupId $resolvedGroup.Id -Property @(
+                'id',
+                'displayName',
+                'description',
+                'groupTypes',
+                'mailEnabled',
+                'mailNickname',
+                'securityEnabled',
+                'visibility',
+                'onPremisesSyncEnabled',
+                'isAssignableToRole'
+            )
+        }
+    }
+    catch {
+        Write-NCMessage "Failed to update description for group '$($resolvedGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+    }
+}
+
+function Set-EntraGroupDisplayName {
+    <#
+    .SYNOPSIS
+        Updates the display name of an Entra group.
+    .DESCRIPTION
+        Resolves an Entra group by display name or object ID and updates only the displayName
+        property in Microsoft Graph.
+    .PARAMETER GroupName
+        Current display name of the target Entra group.
+    .PARAMETER GroupId
+        Object ID of the target Entra group.
+    .PARAMETER DisplayName
+        New display name for the group.
+    .PARAMETER PassThru
+        Emit the updated group object.
+    .EXAMPLE
+        Set-EntraGroupDisplayName -GroupName "GitLab-Prod" -DisplayName "GitLab - Production"
+    .EXAMPLE
+        Set-EntraGroupDisplayName -GroupId "00000000-0000-0000-0000-000000000000" -DisplayName "GitLab - Production" -PassThru
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByName', Position = 0)]
+        [Alias('CurrentName', 'CurrentDisplayName')]
+        [string]$GroupName,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ById')]
+        [string]$GroupId,
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$DisplayName,
+
+        [switch]$PassThru
+    )
+
+    $graphConnected = Test-MgGraphConnection -Scopes @('Group.ReadWrite.All', 'Directory.Read.All') -EnsureExchangeOnline:$false
+    if (-not $graphConnected) {
+        Add-EmptyLine
+        Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+        return
+    }
+
+    if (-not (Get-Command -Name Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+        Write-NCMessage "Invoke-MgGraphRequest is not available in the current Microsoft Graph session." -Level ERROR
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+        Write-NCMessage "DisplayName cannot be empty." -Level WARNING
+        return
+    }
+
+    $resolvedGroup = if ($PSCmdlet.ParameterSetName -eq 'ById') {
+        Resolve-NCEntraGroup -GroupName $GroupId -GroupId $GroupId
+    }
+    else {
+        Resolve-NCEntraGroup -GroupName $GroupName
+    }
+
+    if (-not $resolvedGroup) {
+        return
+    }
+
+    if ($resolvedGroup.OnPremisesSyncEnabled -eq $true) {
+        Write-NCMessage "Group '$($resolvedGroup.DisplayName)' is synchronized from on-premises AD and cannot be renamed directly in Entra." -Level ERROR
+        return
+    }
+
+    if ($resolvedGroup.DisplayName -eq $DisplayName) {
+        Write-NCMessage "Group '$($resolvedGroup.DisplayName)' already has that display name." -Level WARNING
+        if ($PassThru.IsPresent) {
+            Get-MgGroup -GroupId $resolvedGroup.Id -Property @(
+                'id',
+                'displayName',
+                'description',
+                'groupTypes',
+                'mailEnabled',
+                'mailNickname',
+                'securityEnabled',
+                'visibility',
+                'onPremisesSyncEnabled',
+                'isAssignableToRole'
+            )
+        }
+        return
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($resolvedGroup.DisplayName, "Rename group to '$DisplayName'")) {
+        return
+    }
+
+    try {
+        Invoke-MgGraphRequest -Uri "https://graph.microsoft.com/v1.0/groups/$($resolvedGroup.Id)" -Method PATCH -Body (@{ displayName = $DisplayName } | ConvertTo-Json -Depth 10) -ContentType 'application/json' | Out-Null
+        Write-NCMessage "Updated display name for group '$($resolvedGroup.DisplayName)' to '$DisplayName'." -Level SUCCESS
+
+        if ($PassThru.IsPresent) {
+            Get-MgGroup -GroupId $resolvedGroup.Id -Property @(
+                'id',
+                'displayName',
+                'description',
+                'groupTypes',
+                'mailEnabled',
+                'mailNickname',
+                'securityEnabled',
+                'visibility',
+                'onPremisesSyncEnabled',
+                'isAssignableToRole'
+            )
+        }
+    }
+    catch {
+        Write-NCMessage "Failed to update display name for group '$($resolvedGroup.DisplayName)': $($_.Exception.Message)" -Level ERROR
+    }
+}

--- a/Public/NC.Groups.ps1
+++ b/Public/NC.Groups.ps1
@@ -372,6 +372,22 @@ function Export-DistributionGroups {
         Export every distribution group in the tenant.
     .PARAMETER GridView
         Show the result in Out-GridView instead of returning objects.
+    .PARAMETER BatchSize
+        Number of processed groups before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive group-member retrieval failures.
+    .PARAMETER BatchSize
+        Number of processed groups before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive group-member retrieval failures.
     .EXAMPLE
         Export-DistributionGroups -DistributionGroup "Support Team"
     .EXAMPLE
@@ -385,7 +401,13 @@ function Export-DistributionGroups {
         [switch]$Csv,
         [string]$CsvFolder,
         [switch]$All,
-        [switch]$GridView
+        [switch]$GridView,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     begin {
@@ -412,7 +434,7 @@ function Export-DistributionGroups {
             }
 
             $exportAll = $All.IsPresent -or $requestedGroups.Count -eq 0
-            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll
+            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll -or $Resume.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvPath)
             $folder = $null
 
             if ($emitCsv) {
@@ -451,9 +473,97 @@ function Export-DistributionGroups {
                 return
             }
 
+            $normalizeText = {
+                param($value)
+                return Get-NormalizedText -Value $value
+            }
+            $buildMemberKey = {
+                param($row)
+
+                $groupIdentity = & $normalizeText $row.'Group Identity'
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Name'
+                }
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Primary Smtp Address'
+                }
+
+                $memberPrimary = & $normalizeText $row.'Member Primary Smtp Address'
+                $memberDisplay = & $normalizeText $row.'Member Display Name'
+                return "{0}|{1}|{2}" -f $groupIdentity, $memberPrimary, $memberDisplay
+            }
+            $existingMemberKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             $results = [System.Collections.Generic.List[object]]::new()
+            $processedSinceFlush = 0
+            $consecutiveErrors = 0
+            $aborted = $false
+            $csvPathResolved = $null
             $counter = 0
             $total = $groups.Count
+
+            if ($emitCsv) {
+                $folderForExport = $folder
+                $defaultCsvPath = New-File (Join-Path -Path $folderForExport -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DistributionGroups-Report.csv")
+                $csvPathResolved = $defaultCsvPath
+
+                if ($Resume) {
+                    $resumePath = $null
+                    if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                        $resumePath = $CsvPath
+                    }
+                    else {
+                        $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-DistributionGroups-Report.csv" |
+                            Sort-Object LastWriteTime -Descending |
+                            Select-Object -First 1
+                        if ($existingCsv) {
+                            $resumePath = $existingCsv.FullName
+                        }
+                    }
+
+                    if ($resumePath) {
+                        $csvPathResolved = $resumePath
+                        if (Test-Path -LiteralPath $csvPathResolved) {
+                            try {
+                                foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                    $null = $existingMemberKeys.Add((& $buildMemberKey $row))
+                                }
+                                Write-NCMessage ("Resuming distribution group export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingMemberKeys.Count) -Level INFO
+                            }
+                            catch {
+                                Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                                $existingMemberKeys.Clear()
+                                $csvPathResolved = $defaultCsvPath
+                            }
+                        }
+                        else {
+                            Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+                    }
+                }
+
+                Write-NCMessage ("Distribution group export will flush every {0} group(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+                Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+            }
+
+            $writeBuffer = {
+                param([System.Collections.Generic.List[object]]$buffer)
+
+                if ($buffer.Count -eq 0) {
+                    return
+                }
+
+                $exportRows = $buffer | Select-Object 'Group Name', 'Group Identity', 'Group Primary Smtp Address', 'Member Display Name', 'Member FirstName', 'Member LastName', 'Member Primary Smtp Address', 'Member Company', 'Member City'
+                if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                }
+                else {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                }
+                $buffer.Clear()
+            }
 
             foreach ($group in $groups) {
                 $counter++
@@ -465,55 +575,137 @@ function Export-DistributionGroups {
                 }
                 catch {
                     Write-NCMessage "Failed to retrieve members for '$($group.DisplayName)': $($_.Exception.Message)" -Level WARNING
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
                 if (-not $members -or $members.Count -eq 0) {
                     if ($exportAll) {
-                        $results.Add([pscustomobject][ordered]@{
-                                'Group Name'                  = $group.DisplayName
-                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                                'Member Display Name'         = $null
-                                'Member FirstName'            = $null
-                                'Member LastName'             = $null
-                                'Member Primary Smtp Address' = $null
-                                'Member Company'              = $null
-                                'Member City'                 = $null
-                            }) | Out-Null
+                        if ($emitCsv) {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Identity'              = $group.Identity
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
+                        else {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
                     }
+                    $consecutiveErrors = 0
                     continue
                 }
 
                 foreach ($member in $members) {
                     if ($exportAll) {
-                        $row = [ordered]@{
-                            'Group Name'                  = $group.DisplayName
-                            'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
                     else {
-                        $row = [ordered]@{
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
 
-                    $results.Add([pscustomobject]$row) | Out-Null
+                    $rowObject = [pscustomobject]$row
+                    if ($emitCsv) {
+                        $rowKey = & $buildMemberKey $rowObject
+                        if ($Resume -and $existingMemberKeys.Contains($rowKey)) {
+                            continue
+                        }
+                        $null = $existingMemberKeys.Add($rowKey)
+                    }
+
+                    $results.Add($rowObject) | Out-Null
+                }
+
+                $consecutiveErrors = 0
+                if ($emitCsv) {
+                    $processedSinceFlush++
+                    if ($BatchSize -gt 0 -and $results.Count -gt 0 -and $processedSinceFlush -ge $BatchSize) {
+                        & $writeBuffer $results
+                        $processedSinceFlush = 0
+                    }
+                }
+
+                if ($aborted) {
+                    break
                 }
             }
 
+            if ($aborted -and $emitCsv -and $results.Count -gt 0) {
+                & $writeBuffer $results
+            }
+
             if (-not $results -or $results.Count -eq 0) {
-                Write-NCMessage "No members found for the specified distribution groups." -Level WARNING
+                if ($emitCsv -and (Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new distribution group members found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No members found for the specified distribution groups." -Level WARNING
+                }
                 return
             }
 
@@ -521,9 +713,13 @@ function Export-DistributionGroups {
                 $results | Out-GridView -Title "M365 Distribution Groups"
             }
             elseif ($emitCsv) {
-                $csvPath = New-File("$($folder)\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DistributionGroups-Report.csv")
-                $results | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
-                Write-NCMessage "Distribution group membership exported to $csvPath." -Level SUCCESS
+                & $writeBuffer $results
+                if ($aborted) {
+                    Write-NCMessage "Distribution group export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+                }
+                else {
+                    Write-NCMessage "Distribution group membership exported to $csvPathResolved." -Level SUCCESS
+                }
             }
             else {
                 $results
@@ -568,7 +764,13 @@ function Export-DynamicDistributionGroups {
         [switch]$Csv,
         [string]$CsvFolder,
         [switch]$All,
-        [switch]$GridView
+        [switch]$GridView,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     begin {
@@ -595,7 +797,7 @@ function Export-DynamicDistributionGroups {
             }
 
             $exportAll = $All.IsPresent -or $requestedGroups.Count -eq 0
-            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll
+            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll -or $Resume.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvPath)
             $folder = $null
 
             if ($emitCsv) {
@@ -634,9 +836,97 @@ function Export-DynamicDistributionGroups {
                 return
             }
 
+            $normalizeText = {
+                param($value)
+                return Get-NormalizedText -Value $value
+            }
+            $buildMemberKey = {
+                param($row)
+
+                $groupIdentity = & $normalizeText $row.'Group Identity'
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Name'
+                }
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Primary Smtp Address'
+                }
+
+                $memberPrimary = & $normalizeText $row.'Member Primary Smtp Address'
+                $memberDisplay = & $normalizeText $row.'Member Display Name'
+                return "{0}|{1}|{2}" -f $groupIdentity, $memberPrimary, $memberDisplay
+            }
+            $existingMemberKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             $results = [System.Collections.Generic.List[object]]::new()
+            $processedSinceFlush = 0
+            $consecutiveErrors = 0
+            $aborted = $false
+            $csvPathResolved = $null
             $counter = 0
             $total = $groups.Count
+
+            if ($emitCsv) {
+                $folderForExport = $folder
+                $defaultCsvPath = New-File (Join-Path -Path $folderForExport -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DynamicDistributionGroups-Report.csv")
+                $csvPathResolved = $defaultCsvPath
+
+                if ($Resume) {
+                    $resumePath = $null
+                    if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                        $resumePath = $CsvPath
+                    }
+                    else {
+                        $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-DynamicDistributionGroups-Report.csv" |
+                            Sort-Object LastWriteTime -Descending |
+                            Select-Object -First 1
+                        if ($existingCsv) {
+                            $resumePath = $existingCsv.FullName
+                        }
+                    }
+
+                    if ($resumePath) {
+                        $csvPathResolved = $resumePath
+                        if (Test-Path -LiteralPath $csvPathResolved) {
+                            try {
+                                foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                    $null = $existingMemberKeys.Add((& $buildMemberKey $row))
+                                }
+                                Write-NCMessage ("Resuming dynamic distribution group export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingMemberKeys.Count) -Level INFO
+                            }
+                            catch {
+                                Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                                $existingMemberKeys.Clear()
+                                $csvPathResolved = $defaultCsvPath
+                            }
+                        }
+                        else {
+                            Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+                    }
+                }
+
+                Write-NCMessage ("Dynamic distribution group export will flush every {0} group(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+                Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+            }
+
+            $writeBuffer = {
+                param([System.Collections.Generic.List[object]]$buffer)
+
+                if ($buffer.Count -eq 0) {
+                    return
+                }
+
+                $exportRows = $buffer | Select-Object 'Group Name', 'Group Identity', 'Group Primary Smtp Address', 'Member Display Name', 'Member FirstName', 'Member LastName', 'Member Primary Smtp Address', 'Member Company', 'Member City'
+                if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                }
+                else {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                }
+                $buffer.Clear()
+            }
 
             foreach ($group in $groups) {
                 $counter++
@@ -648,55 +938,137 @@ function Export-DynamicDistributionGroups {
                 }
                 catch {
                     Write-NCMessage "Failed to retrieve members for '$($group.DisplayName)': $($_.Exception.Message)" -Level WARNING
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
                 if (-not $members -or $members.Count -eq 0) {
                     if ($exportAll) {
-                        $results.Add([pscustomobject][ordered]@{
-                                'Group Name'                  = $group.DisplayName
-                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                                'Member Display Name'         = $null
-                                'Member FirstName'            = $null
-                                'Member LastName'             = $null
-                                'Member Primary Smtp Address' = $null
-                                'Member Company'              = $null
-                                'Member City'                 = $null
-                            }) | Out-Null
+                        if ($emitCsv) {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Identity'              = $group.Identity
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
+                        else {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
                     }
+                    $consecutiveErrors = 0
                     continue
                 }
 
                 foreach ($member in $members) {
                     if ($exportAll) {
-                        $row = [ordered]@{
-                            'Group Name'                  = $group.DisplayName
-                            'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
                     else {
-                        $row = [ordered]@{
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
 
-                    $results.Add([pscustomobject]$row) | Out-Null
+                    $rowObject = [pscustomobject]$row
+                    if ($emitCsv) {
+                        $rowKey = & $buildMemberKey $rowObject
+                        if ($Resume -and $existingMemberKeys.Contains($rowKey)) {
+                            continue
+                        }
+                        $null = $existingMemberKeys.Add($rowKey)
+                    }
+
+                    $results.Add($rowObject) | Out-Null
+                }
+
+                $consecutiveErrors = 0
+                if ($emitCsv) {
+                    $processedSinceFlush++
+                    if ($BatchSize -gt 0 -and $results.Count -gt 0 -and $processedSinceFlush -ge $BatchSize) {
+                        & $writeBuffer $results
+                        $processedSinceFlush = 0
+                    }
+                }
+
+                if ($aborted) {
+                    break
                 }
             }
 
+            if ($aborted -and $emitCsv -and $results.Count -gt 0) {
+                & $writeBuffer $results
+            }
+
             if (-not $results -or $results.Count -eq 0) {
-                Write-NCMessage "No members found for the specified dynamic distribution groups." -Level WARNING
+                if ($emitCsv -and (Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new dynamic distribution group members found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No members found for the specified dynamic distribution groups." -Level WARNING
+                }
                 return
             }
 
@@ -704,9 +1076,13 @@ function Export-DynamicDistributionGroups {
                 $results | Out-GridView -Title "M365 Dynamic Distribution Groups"
             }
             elseif ($emitCsv) {
-                $csvPath = New-File("$($folder)\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DynamicDistributionGroups-Report.csv")
-                $results | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
-                Write-NCMessage "Dynamic distribution group membership exported to $csvPath." -Level SUCCESS
+                & $writeBuffer $results
+                if ($aborted) {
+                    Write-NCMessage "Dynamic distribution group export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+                }
+                else {
+                    Write-NCMessage "Dynamic distribution group membership exported to $csvPathResolved." -Level SUCCESS
+                }
             }
             else {
                 $results
@@ -778,7 +1154,7 @@ function Export-M365Group {
             }
 
             $exportAll = $All.IsPresent -or $requestedGroups.Count -eq 0
-            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll
+            $emitCsv = $Csv.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvFolder) -or $exportAll -or $Resume.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvPath)
             $folder = $null
 
             if ($emitCsv) {
@@ -817,9 +1193,97 @@ function Export-M365Group {
                 return
             }
 
+            $normalizeText = {
+                param($value)
+                return Get-NormalizedText -Value $value
+            }
+            $buildMemberKey = {
+                param($row)
+
+                $groupIdentity = & $normalizeText $row.'Group Identity'
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Name'
+                }
+                if (-not $groupIdentity) {
+                    $groupIdentity = & $normalizeText $row.'Group Primary Smtp Address'
+                }
+
+                $memberPrimary = & $normalizeText $row.'Member Primary Smtp Address'
+                $memberDisplay = & $normalizeText $row.'Member Display Name'
+                return "{0}|{1}|{2}" -f $groupIdentity, $memberPrimary, $memberDisplay
+            }
+            $existingMemberKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             $results = [System.Collections.Generic.List[object]]::new()
+            $processedSinceFlush = 0
+            $consecutiveErrors = 0
+            $aborted = $false
+            $csvPathResolved = $null
             $counter = 0
             $total = $groups.Count
+
+            if ($emitCsv) {
+                $folderForExport = $folder
+                $defaultCsvPath = New-File (Join-Path -Path $folderForExport -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-UnifiedGroups-Report.csv")
+                $csvPathResolved = $defaultCsvPath
+
+                if ($Resume) {
+                    $resumePath = $null
+                    if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                        $resumePath = $CsvPath
+                    }
+                    else {
+                        $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-UnifiedGroups-Report.csv" |
+                            Sort-Object LastWriteTime -Descending |
+                            Select-Object -First 1
+                        if ($existingCsv) {
+                            $resumePath = $existingCsv.FullName
+                        }
+                    }
+
+                    if ($resumePath) {
+                        $csvPathResolved = $resumePath
+                        if (Test-Path -LiteralPath $csvPathResolved) {
+                            try {
+                                foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                    $null = $existingMemberKeys.Add((& $buildMemberKey $row))
+                                }
+                                Write-NCMessage ("Resuming Microsoft 365 group export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingMemberKeys.Count) -Level INFO
+                            }
+                            catch {
+                                Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                                $existingMemberKeys.Clear()
+                                $csvPathResolved = $defaultCsvPath
+                            }
+                        }
+                        else {
+                            Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+                    }
+                }
+
+                Write-NCMessage ("Microsoft 365 group export will flush every {0} group(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+                Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+            }
+
+            $writeBuffer = {
+                param([System.Collections.Generic.List[object]]$buffer)
+
+                if ($buffer.Count -eq 0) {
+                    return
+                }
+
+                $exportRows = $buffer | Select-Object 'Group Name', 'Group Identity', 'Group Primary Smtp Address', 'Member Display Name', 'Member FirstName', 'Member LastName', 'Member Primary Smtp Address', 'Member Company', 'Member City'
+                if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                }
+                else {
+                    $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                }
+                $buffer.Clear()
+            }
 
             foreach ($group in $groups) {
                 $counter++
@@ -831,55 +1295,137 @@ function Export-M365Group {
                 }
                 catch {
                     Write-NCMessage "Failed to retrieve members for '$($group.DisplayName)': $($_.Exception.Message)" -Level WARNING
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
                 if (-not $members -or $members.Count -eq 0) {
                     if ($exportAll) {
-                        $results.Add([pscustomobject][ordered]@{
-                                'Group Name'                  = $group.DisplayName
-                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                                'Member Display Name'         = $null
-                                'Member FirstName'            = $null
-                                'Member LastName'             = $null
-                                'Member Primary Smtp Address' = $null
-                                'Member Company'              = $null
-                                'Member City'                 = $null
-                            }) | Out-Null
+                        if ($emitCsv) {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Identity'              = $group.Identity
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
+                        else {
+                            $results.Add([pscustomobject][ordered]@{
+                                    'Group Name'                  = $group.DisplayName
+                                    'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                    'Member Display Name'         = $null
+                                    'Member FirstName'            = $null
+                                    'Member LastName'             = $null
+                                    'Member Primary Smtp Address' = $null
+                                    'Member Company'              = $null
+                                    'Member City'                 = $null
+                                }) | Out-Null
+                        }
                     }
+                    $consecutiveErrors = 0
                     continue
                 }
 
                 foreach ($member in $members) {
                     if ($exportAll) {
-                        $row = [ordered]@{
-                            'Group Name'                  = $group.DisplayName
-                            'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
                     else {
-                        $row = [ordered]@{
-                            'Member Display Name'         = $member.DisplayName
-                            'Member FirstName'            = $member.FirstName
-                            'Member LastName'             = $member.LastName
-                            'Member Primary Smtp Address' = $member.PrimarySmtpAddress
-                            'Member Company'              = $member.Company
-                            'Member City'                 = $member.City
+                        if ($emitCsv) {
+                            $row = [ordered]@{
+                                'Group Name'                  = $group.DisplayName
+                                'Group Identity'              = $group.Identity
+                                'Group Primary Smtp Address'  = $group.PrimarySmtpAddress
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
+                        }
+                        else {
+                            $row = [ordered]@{
+                                'Member Display Name'         = $member.DisplayName
+                                'Member FirstName'            = $member.FirstName
+                                'Member LastName'             = $member.LastName
+                                'Member Primary Smtp Address' = $member.PrimarySmtpAddress
+                                'Member Company'              = $member.Company
+                                'Member City'                 = $member.City
+                            }
                         }
                     }
 
-                    $results.Add([pscustomobject]$row) | Out-Null
+                    $rowObject = [pscustomobject]$row
+                    if ($emitCsv) {
+                        $rowKey = & $buildMemberKey $rowObject
+                        if ($Resume -and $existingMemberKeys.Contains($rowKey)) {
+                            continue
+                        }
+                        $null = $existingMemberKeys.Add($rowKey)
+                    }
+
+                    $results.Add($rowObject) | Out-Null
+                }
+
+                $consecutiveErrors = 0
+                if ($emitCsv) {
+                    $processedSinceFlush++
+                    if ($BatchSize -gt 0 -and $results.Count -gt 0 -and $processedSinceFlush -ge $BatchSize) {
+                        & $writeBuffer $results
+                        $processedSinceFlush = 0
+                    }
+                }
+
+                if ($aborted) {
+                    break
                 }
             }
 
+            if ($aborted -and $emitCsv -and $results.Count -gt 0) {
+                & $writeBuffer $results
+            }
+
             if (-not $results -or $results.Count -eq 0) {
-                Write-NCMessage "No members found for the specified Microsoft 365 groups." -Level WARNING
+                if ($emitCsv -and (Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new Microsoft 365 group members found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No members found for the specified Microsoft 365 groups." -Level WARNING
+                }
                 return
             }
 
@@ -887,9 +1433,13 @@ function Export-M365Group {
                 $results | Out-GridView -Title "M365 Unified Groups"
             }
             elseif ($emitCsv) {
-                $csvPath = New-File("$($folder)\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-UnifiedGroups-Report.csv")
-                $results | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
-                Write-NCMessage "Microsoft 365 group membership exported to $csvPath." -Level SUCCESS
+                & $writeBuffer $results
+                if ($aborted) {
+                    Write-NCMessage "Microsoft 365 group export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+                }
+                else {
+                    Write-NCMessage "Microsoft 365 group membership exported to $csvPathResolved." -Level SUCCESS
+                }
             }
             else {
                 $results

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -295,7 +295,7 @@ function Export-IntuneAppInventory {
             foreach ($device in $devices) {
                 $processed++
 
-                $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $processed -Total $devices.Count
                 Write-Progress -Activity "Reading Detected Apps" -Status "$($device.deviceName) - $processed / $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -341,7 +341,7 @@ function Export-IntuneAppInventory {
                         Start-Sleep -Seconds 60
                         $processed--
 
-                        $Percentage = [Math]::Round(($processed / [Math]::Max($devices.Count, 1)) * 100, 2)
+                        $Percentage = Get-NCProgressPercent -Current $processed -Total $devices.Count
                         Write-Progress -Activity "Reading Detected Apps" -Status "Waiting after rate limit ... - $processed / $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                         continue
@@ -599,7 +599,7 @@ function New-IntuneAppBasedGroup {
             foreach ($device in $devices) {
                 $processedDevices++
 
-                $Percentage = [Math]::Round(($processedDevices / [Math]::Max($devices.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $processed -Total $devices.Count
                 Write-Progress -Activity 'Processing Devices' -Status "$($device.deviceName) - $processedDevices of $($devices.Count) devices - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -842,7 +842,7 @@ function New-IntuneAppBasedGroup {
                     $processedMembers++
 
                     try {
-                        $Percentage = [Math]::Round(($processedMembers / [Math]::Max($uniqueDeviceIds.Count, 1)) * 100, 2)
+                        $Percentage = Get-NCProgressPercent -Current $processed -Total $uniqueDeviceIds.Count
                         $resolution = Resolve-NCIntuneManagedDeviceEntraMember -ManagedDevices $devices -DeviceId $deviceId
                         $deviceLabel = if ($resolution -and -not [string]::IsNullOrWhiteSpace($resolution.DeviceName)) { $resolution.DeviceName } else { [string]$deviceId }
                         Write-Progress -Activity 'Resolving Entra Devices' -Status "$deviceLabel - $processedMembers of $($uniqueDeviceIds.Count) devices - $Percentage%" -PercentComplete $Percentage
@@ -999,3 +999,5 @@ function New-IntuneAppBasedGroup {
         }
     }
 }
+
+

--- a/Public/NC.Intune.ps1
+++ b/Public/NC.Intune.ps1
@@ -218,6 +218,14 @@ function Export-IntuneAppInventory {
         Optional CSV export path.
     .PARAMETER OutputJsonPath
         Optional JSON export path.
+    .PARAMETER BatchSize
+        Number of rows to flush at a time when writing CSV output.
+    .PARAMETER Resume
+        Resume CSV export from the latest matching CSV or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume or export to. When omitted, a default file is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive device-level failures.
     .PARAMETER PivotSummary
         Print a per-app summary after the report is built.
     .EXAMPLE
@@ -247,6 +255,12 @@ function Export-IntuneAppInventory {
 
         [string]$OutputCsvPath,
         [string]$OutputJsonPath,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5,
         [switch]$PivotSummary
     )
 
@@ -274,6 +288,28 @@ function Export-IntuneAppInventory {
                 Write-NCMessage "ApplicationName cannot be empty." -Level WARNING
                 return
             }
+
+            $normalizeText = {
+                param($value)
+                return Get-NormalizedText -Value $value
+            }
+            $buildRowKey = {
+                param($row)
+
+                $app = & $normalizeText $row.AppName
+                $device = & $normalizeText $row.DeviceId
+                $source = & $normalizeText $row.Source
+                $installState = & $normalizeText $row.InstallState
+                $version = & $normalizeText $row.Version
+                $publisher = & $normalizeText $row.Publisher
+                return "{0}|{1}|{2}|{3}|{4}|{5}" -f $app, $device, $source, $installState, $version, $publisher
+            }
+            $existingRowKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $exportCsv = $false
+            $csvPathResolved = $null
+            $processedSinceFlush = 0
+            $consecutiveErrors = 0
+            $aborted = $false
 
             Write-NCMessage "Starting app inventory reporting ..." -Level INFO
 
@@ -347,6 +383,15 @@ function Export-IntuneAppInventory {
                         continue
                     }
                     Write-NCMessage "Error reading apps for $($device.deviceName): $($_.Exception.Message)" -Level WARNING
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        $aborted = $true
+                        break
+                    }
+                }
+
+                if ($aborted) {
+                    break
                 }
             }
             Write-Progress -Activity "Reading Detected Apps" -Completed
@@ -424,8 +469,53 @@ function Export-IntuneAppInventory {
                 }
             }
 
+            if ($OutputCsvPath -or $Resume.IsPresent -or -not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                    $csvPathResolved = $CsvPath
+                }
+                elseif (-not [string]::IsNullOrWhiteSpace($OutputCsvPath)) {
+                    $csvPathResolved = $OutputCsvPath
+                }
+                elseif ($Resume) {
+                    $existingCsv = Get-ChildItem -Path (Get-Location).Path -File -Filter "*_M365-IntuneAppInventory-Report.csv" |
+                        Sort-Object LastWriteTime -Descending |
+                        Select-Object -First 1
+                    if ($existingCsv) {
+                        $csvPathResolved = $existingCsv.FullName
+                    }
+                    else {
+                        $csvPathResolved = New-File (Join-Path -Path (Get-Location).Path -ChildPath "$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-IntuneAppInventory-Report.csv")
+                    }
+                }
+
+                if ($Resume -and (Test-Path -LiteralPath $csvPathResolved)) {
+                    try {
+                        foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                            $null = $existingRowKeys.Add((& $buildRowKey $row))
+                        }
+                        Write-NCMessage ("Resuming Intune app inventory export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingRowKeys.Count) -Level INFO
+                    }
+                    catch {
+                        Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                        $existingRowKeys.Clear()
+                    }
+                }
+                elseif ($Resume -and -not (Test-Path -LiteralPath $csvPathResolved)) {
+                    Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                }
+
+                $exportCsv = $true
+                Write-NCMessage ("Intune app inventory CSV export will flush every {0} row(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+                Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+            }
+
             if (-not $rows -or $rows.Count -eq 0) {
-                Write-NCMessage "No applications matched '$ApplicationName' with the provided filters." -Level WARNING
+                if ($exportCsv -and (Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new Intune app inventory rows found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No applications matched '$ApplicationName' with the provided filters." -Level WARNING
+                }
                 return
             }
 
@@ -433,10 +523,32 @@ function Export-IntuneAppInventory {
             $rows | Sort-Object AppName, DeviceName | Format-Table -AutoSize AppName, Version, DeviceName, Platform, User, Source
 
             # Optional exports
-            if ($OutputCsvPath) {
+            if ($exportCsv) {
                 try {
-                    $rows | Sort-Object AppName, DeviceName | Export-Csv -Path $OutputCsvPath -NoTypeInformation -Encoding UTF8
-                    Write-NCMessage "CSV exported to $OutputCsvPath" -Level SUCCESS
+                    $sortedRows = $rows | Sort-Object AppName, DeviceName, DeviceId, Source
+                    $exportRows = if ($Resume) { @($sortedRows | Where-Object { -not $existingRowKeys.Contains((& $buildRowKey $_)) }) } else { @($sortedRows) }
+
+                    if ($exportRows.Count -eq 0) {
+                        Write-NCMessage "No new CSV rows needed to be written to $csvPathResolved." -Level INFO
+                    }
+                    else {
+                        $chunkSize = if ($BatchSize -gt 0) { $BatchSize } else { $exportRows.Count }
+                        for ($offset = 0; $offset -lt $exportRows.Count; $offset += $chunkSize) {
+                            $chunk = $exportRows[$offset..([Math]::Min($offset + $chunkSize - 1, $exportRows.Count - 1))]
+                            if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                                $chunk | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding UTF8 -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                            }
+                            else {
+                                $chunk | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding UTF8 -Delimiter $NCVars.CSV_DefaultLimiter
+                            }
+                        }
+                        if ($aborted) {
+                            Write-NCMessage "Intune app inventory CSV export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+                        }
+                        else {
+                            Write-NCMessage "CSV exported to $csvPathResolved" -Level SUCCESS
+                        }
+                    }
                 }
                 catch {
                     Write-NCMessage "Failed to export CSV: $($_.Exception.Message)" -Level WARNING

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -746,7 +746,7 @@ function Export-MsolAccountSku {
 
         foreach ($User in $Users) {
             $ProcessedCount++
-            $Percentage = [Math]::Round(($ProcessedCount / [Math]::Max($totalUsers, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $ProcessedCount -Total $totalUsers
             Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers - $Percentage%" -PercentComplete $Percentage
 
             if ($ProcessedUsers -contains $User.UserPrincipalName) {
@@ -852,6 +852,7 @@ function Export-MsolAccountSku {
         }
 
         $arr_MsolAccountSku | Export-CSV $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding)
+        Write-NCMessage "User license report exported to $CSV." -Level SUCCESS
 
         if ($resolvedViaCustom.Count -gt 0) {
             Write-NCMessage "Licenses not found, but resolved via custom catalog:" -Level WARNING
@@ -888,6 +889,9 @@ function Get-TenantMsolAccountSku {
         Force a fresh download of the cached license catalog before processing.
     .PARAMETER Filter
         Filters the output to licenses whose name or SkuPartNumber contains the provided text.
+    .PARAMETER Domain
+        Optional domain filter for sample users. When specified, sample users are limited to
+        accounts whose Mail, UserPrincipalName, or ProxyAddresses belong to the selected domain.
     .PARAMETER SampleUsers
         Returns up to N sample users for each matching SKU (requires -Filter).
     .PARAMETER IncludeSampleUsers
@@ -906,11 +910,14 @@ function Get-TenantMsolAccountSku {
         Get-TenantMsolAccountSku -Filter "E3" -SampleUsers 5
     .EXAMPLE
         Get-TenantMsolAccountSku -Filter "E3" -IncludeSampleUsers
+    .EXAMPLE
+        Get-TenantMsolAccountSku -Filter "E3" -SampleUsers 5 -Domain "contoso.com"
     #>
     [CmdletBinding()]
     param(
         [switch]$ForceLicenseCatalogRefresh,
         [string]$Filter,
+        [string]$Domain,
         [int]$SampleUsers = 5,
         [switch]$IncludeSampleUsers,
         [switch]$AsTable,
@@ -964,6 +971,65 @@ function Get-TenantMsolAccountSku {
         if ($useSampleUsers -and -not $Filter) {
             Write-NCMessage "SampleUsers requires -Filter to limit the query scope. Example: Get-TenantMsolAccountSku -Filter \"E3\" -SampleUsers 5" -Level ERROR
             return
+        }
+
+        $normalizedDomain = $null
+        if (-not [string]::IsNullOrWhiteSpace($Domain)) {
+            $normalizedDomain = $Domain.Trim().ToLowerInvariant().TrimStart('@')
+            if ([string]::IsNullOrWhiteSpace($normalizedDomain)) {
+                Write-NCMessage "Domain filter cannot be empty." -Level ERROR
+                return
+            }
+            else {
+                Write-Verbose "Filtering sample users for domain '$normalizedDomain'."
+            }
+        }
+
+        $getAddressDomain = {
+            param($value)
+
+            if ([string]::IsNullOrWhiteSpace($value)) {
+                return $null
+            }
+
+            $address = [string]$value
+            if ($address.Contains(':')) {
+                $address = $address.Substring($address.IndexOf(':') + 1)
+            }
+
+            $atIndex = $address.LastIndexOf('@')
+            if ($atIndex -lt 0 -or $atIndex -eq ($address.Length - 1)) {
+                return $null
+            }
+
+            return $address.Substring($atIndex + 1).Trim().ToLowerInvariant()
+        }
+
+        $matchesDomain = {
+            param($user)
+
+            if (-not $normalizedDomain) {
+                return $true
+            }
+
+            $domains = @()
+            foreach ($candidate in @($user.Mail, $user.UserPrincipalName)) {
+                $candidateDomain = & $getAddressDomain $candidate
+                if ($candidateDomain) {
+                    $domains += $candidateDomain
+                }
+            }
+
+            if ($user.PSObject.Properties['ProxyAddresses'] -and $user.ProxyAddresses) {
+                foreach ($proxy in $user.ProxyAddresses) {
+                    $proxyDomain = & $getAddressDomain $proxy
+                    if ($proxyDomain) {
+                        $domains += $proxyDomain
+                    }
+                }
+            }
+
+            return ($domains | Select-Object -Unique) -contains $normalizedDomain
         }
 
         $results = foreach ($sku in $skus) {
@@ -1022,11 +1088,23 @@ function Get-TenantMsolAccountSku {
                 $sampleUserList = @()
                 try {
                     $examples = Invoke-NCRetry -Action {
-                        Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
-                            -Top $sampleUserLimit `
-                            -ConsistencyLevel eventual `
-                            -Property Id,UserPrincipalName,DisplayName `
-                            -ErrorAction Stop
+                        if ($normalizedDomain) {
+                            Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
+                                -All `
+                                -ConsistencyLevel eventual `
+                                -Property Id,UserPrincipalName,DisplayName,Mail,ProxyAddresses `
+                                -ErrorAction Stop |
+                                Where-Object { & $matchesDomain $_ } |
+                                Select-Object -First $sampleUserLimit
+                        }
+                        else {
+                            Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
+                                -Top $sampleUserLimit `
+                                -ConsistencyLevel eventual `
+                                -Property Id,UserPrincipalName,DisplayName `
+                                -ErrorAction Stop |
+                                Select-Object -First $sampleUserLimit
+                        }
                     } -MaxAttempts $maxAttempts -DelaySeconds 5 -OperationDescription "retrieve sample users for $($sku.SkuPartNumber)" -OnError {
                         param($attempt, $max, $err)
                         $currentAttempt = if ($attempt) { $attempt } else { '?' }
@@ -1860,3 +1938,5 @@ function Update-LicenseCatalog {
         throw
     }
 }
+
+

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -243,6 +243,288 @@ function Add-UserMsolAccountSku {
     }
 }
 
+function Set-UserUsageLocation {
+    <#
+    .SYNOPSIS
+        Updates usage location for one or more users.
+    .DESCRIPTION
+        Resolves users from pipeline or explicit input, connects to Microsoft Graph, and updates
+        their UsageLocation value. If -UsageLocation is omitted, Nebula.Core uses the configured
+        UsageLocation default (or US when no override exists).
+    .PARAMETER UserPrincipalName
+        User principal name, object ID, or short identifier. Accepts pipeline input.
+    .PARAMETER UsageLocation
+        Two-letter country code to set. When omitted, the configured default is used.
+    .PARAMETER PassThru
+        Emit the processed users as objects.
+    .EXAMPLE
+        Set-UserUsageLocation -UserPrincipalName user@contoso.com -UsageLocation IT
+    .EXAMPLE
+        'user1@contoso.com','user2@contoso.com' | Set-UserUsageLocation -UsageLocation DE
+    .EXAMPLE
+        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Set-UserUsageLocation -UsageLocation FR
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'UPN', 'Identity')]
+        [string[]]$UserPrincipalName,
+        [string]$UsageLocation,
+        [switch]$PassThru
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $UserPrincipalName) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if ($targets.Count -eq 0) {
+                Write-NCMessage "No user principal names provided." -Level WARNING
+                return
+            }
+
+            $GraphConnection = Test-MgGraphConnection -Scopes @('Directory.ReadWrite.All') -EnsureExchangeOnline:$false
+            if (-not $GraphConnection) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $defaultUsageLocation = if (-not [string]::IsNullOrWhiteSpace($UsageLocation)) {
+                $UsageLocation.Trim()
+            }
+            elseif (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
+                [string]$NCVars.UsageLocation
+            }
+            else {
+                'US'
+            }
+
+            $targetUsage = $defaultUsageLocation.Trim().ToUpperInvariant()
+            if ($targetUsage.Length -ne 2) {
+                Write-NCMessage "UsageLocation must be a two-letter country code." -Level ERROR
+                return
+            }
+
+            $normalizeUsageLocation = {
+                param($value)
+                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
+                return $value.Trim().ToUpperInvariant()
+            }
+
+            $queue = [System.Collections.Generic.List[string]]::new()
+            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($entry in $targets) {
+                if ($dedup.Add($entry)) {
+                    $queue.Add($entry) | Out-Null
+                }
+            }
+
+            $results = [System.Collections.Generic.List[object]]::new()
+            $updatedCount = 0
+            $skippedCount = 0
+            $counter = 0
+
+            foreach ($upn in $queue) {
+                $counter++
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
+
+                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
+                if (-not $resolvedPrincipal) {
+                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
+                    continue
+                }
+
+                try {
+                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
+                }
+                catch {
+                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
+                    continue
+                }
+
+                $currentUsage = & $normalizeUsageLocation $user.UsageLocation
+                if ($currentUsage -eq $targetUsage) {
+                    $skippedCount++
+                    if ($PassThru.IsPresent) {
+                        $results.Add([pscustomobject]@{
+                                UserPrincipalName     = $user.UserPrincipalName
+                                DisplayName           = $user.DisplayName
+                                PreviousUsageLocation = $user.UsageLocation
+                                UsageLocation         = $user.UsageLocation
+                                Action                = 'Skipped'
+                            }) | Out-Null
+                    }
+                    Write-Verbose "Usage location already set to $targetUsage for $($user.UserPrincipalName)."
+                    continue
+                }
+
+                if (-not $PSCmdlet.ShouldProcess($user.UserPrincipalName, "Set usage location to $targetUsage")) {
+                    continue
+                }
+
+                try {
+                    Update-MgUser -UserId $user.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
+                    $updatedCount++
+                    if ($PassThru.IsPresent) {
+                        $results.Add([pscustomobject]@{
+                                UserPrincipalName     = $user.UserPrincipalName
+                                DisplayName           = $user.DisplayName
+                                PreviousUsageLocation = $user.UsageLocation
+                                UsageLocation         = $targetUsage
+                                Action                = 'Updated'
+                            }) | Out-Null
+                    }
+                    Write-Verbose "Usage location set to $targetUsage for $($user.UserPrincipalName)."
+                }
+                catch {
+                    Write-NCMessage "Unable to set usage location ($targetUsage) for $($user.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
+                }
+            }
+
+            if ($PassThru.IsPresent) {
+                $results
+            }
+            elseif ($updatedCount -gt 0) {
+                $summary = "Usage location updated for {0} user(s) to {1}." -f $updatedCount, $targetUsage
+                if ($skippedCount -gt 0) {
+                    $summary = $summary + (" {0} user(s) already had that value." -f $skippedCount)
+                }
+                Write-NCMessage $summary -Level SUCCESS
+            }
+            elseif ($skippedCount -gt 0) {
+                Write-NCMessage ("Usage location already set to {0} for {1} user(s)." -f $targetUsage, $skippedCount) -Level INFO
+            }
+            else {
+                Write-NCMessage "No usage location changes were applied." -Level WARNING
+            }
+        }
+        finally {
+            Write-Progress -Activity "Processing users" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
+function Get-UserUsageLocation {
+    <#
+    .SYNOPSIS
+        Reads the current usage location for one or more users.
+    .DESCRIPTION
+        Resolves users from pipeline or explicit input and returns their current UsageLocation
+        from Microsoft Graph. The output also includes the configured NebulaCore default so the
+        current value can be compared against the environment setting at a glance.
+    .PARAMETER UserPrincipalName
+        User principal name, object ID, or short identifier. Accepts pipeline input.
+    .EXAMPLE
+        Get-UserUsageLocation -UserPrincipalName user@contoso.com
+    .EXAMPLE
+        'user1@contoso.com','user2@contoso.com' | Get-UserUsageLocation
+    .EXAMPLE
+        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Get-UserUsageLocation
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'UPN', 'Identity')]
+        [string[]]$UserPrincipalName
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $UserPrincipalName) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if ($targets.Count -eq 0) {
+                Write-NCMessage "No user principal names provided." -Level WARNING
+                return
+            }
+
+            $GraphConnection = Test-MgGraphConnection -Scopes @('User.Read.All') -EnsureExchangeOnline:$false
+            if (-not $GraphConnection) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $defaultUsageLocation = if (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
+                [string]$NCVars.UsageLocation
+            }
+            else {
+                'US'
+            }
+
+            $normalizeUsageLocation = {
+                param($value)
+                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
+                return $value.Trim().ToUpperInvariant()
+            }
+
+            $queue = [System.Collections.Generic.List[string]]::new()
+            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($entry in $targets) {
+                if ($dedup.Add($entry)) {
+                    $queue.Add($entry) | Out-Null
+                }
+            }
+
+            $counter = 0
+            foreach ($upn in $queue) {
+                $counter++
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
+
+                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
+                if (-not $resolvedPrincipal) {
+                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
+                    continue
+                }
+
+                try {
+                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
+                }
+                catch {
+                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
+                    continue
+                }
+
+                [pscustomobject]@{
+                    UserPrincipalName                = $user.UserPrincipalName
+                    DisplayName                      = $user.DisplayName
+                    UsageLocation                    = $user.UsageLocation
+                    ConfiguredDefaultUsageLocation   = $defaultUsageLocation
+                    MatchesConfiguredDefault         = (& $normalizeUsageLocation $user.UsageLocation) -eq (& $normalizeUsageLocation $defaultUsageLocation)
+                }
+            }
+        }
+        finally {
+            Write-Progress -Activity "Processing users" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
 function Copy-UserMsolAccountSku {
     <#
     .SYNOPSIS
@@ -496,6 +778,14 @@ function Export-MsolAccountSku {
         Force a fresh download of the cached license catalog before processing.
     .PARAMETER ShowErrorDetails
         Include exception details in error messages.
+    .PARAMETER BatchSize
+        Number of processed users before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive user-level failures.
     .EXAMPLE
         Export-MsolAccountSku
     .EXAMPLE
@@ -511,7 +801,13 @@ function Export-MsolAccountSku {
         [string]$CSVFolder,
         [string]$Domain,
         [string[]]$License,
-        [switch]$ForceLicenseCatalogRefresh
+        [switch]$ForceLicenseCatalogRefresh,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 50,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     Set-ProgressAndInfoPreferences
@@ -556,8 +852,11 @@ function Export-MsolAccountSku {
                 return
             }
         }
-        $arr_MsolAccountSku = @()
-        $ProcessedCount = 0
+        $reportBuffer = [System.Collections.Generic.List[object]]::new()
+        $processedCount = 0
+        $processedSinceFlush = 0
+        $consecutiveErrors = 0
+        $aborted = $false
         $maxAttempts = 3
         $resolvedViaCustom = @{}
         $unknownSkuTracker = @{}
@@ -719,13 +1018,54 @@ function Export-MsolAccountSku {
             return ($domains | Select-Object -Unique) -contains $normalizedDomain
         }
 
-        $CSV = New-File("$($folder)\$((Get-Date -Format $($NCVars.DateTimeString_CSV)).ToString())_M365-User-License-Report.csv")
-        if (Test-Path $CSV) {
-            $ProcessedUsers = Import-CSV $CSV | Select-Object -ExpandProperty UserPrincipalName
+        $defaultCsvPath = New-File("$($folder)\$((Get-Date -Format $($NCVars.DateTimeString_CSV)).ToString())_M365-User-License-Report.csv")
+        $CSV = $defaultCsvPath
+        $processedUsers = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+        if ($Resume) {
+            $resumePath = $null
+            if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                $resumePath = $CsvPath
+            }
+            else {
+                $existingCsv = Get-ChildItem -LiteralPath $folder -File -Filter "*_M365-User-License-Report.csv" |
+                    Sort-Object LastWriteTime -Descending |
+                    Select-Object -First 1
+                if ($existingCsv) {
+                    $resumePath = $existingCsv.FullName
+                }
+            }
+
+            if ($resumePath) {
+                $CSV = $resumePath
+                if (Test-Path -LiteralPath $CSV) {
+                    try {
+                        foreach ($row in (Import-CSV -LiteralPath $CSV -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                            $identity = if ($row.UserPrincipalName) { [string]$row.UserPrincipalName } else { $null }
+                            if ($identity) {
+                                $null = $processedUsers.Add($identity.Trim())
+                            }
+                        }
+                        Write-NCMessage ("Resuming user license export from {0}; {1} user(s) already recorded." -f $CSV, $processedUsers.Count) -Level INFO
+                    }
+                    catch {
+                        Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $CSV, $_.Exception.Message) -Level WARNING
+                        $processedUsers.Clear()
+                        $CSV = $defaultCsvPath
+                    }
+                }
+                else {
+                    Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $CSV) -Level INFO
+                }
+            }
+            else {
+                $CSV = $defaultCsvPath
+                Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $CSV) -Level INFO
+            }
         }
-        else {
-            $ProcessedUsers = @()
-        }
+
+        Write-NCMessage ("User license export will flush every {0} user(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+        Write-NCMessage "Saving report to $CSV" -Level DEBUG
 
         try {
             $Users = Get-MgUser -Filter 'assignedLicenses/$count ne 0' -ConsistencyLevel eventual -CountVariable totalUsers -All -Property Id,DisplayName,UserPrincipalName,Mail,ProxyAddresses -ErrorAction Stop
@@ -745,14 +1085,16 @@ function Export-MsolAccountSku {
         }
 
         foreach ($User in $Users) {
-            $ProcessedCount++
-            $Percentage = Get-NCProgressPercent -Current $ProcessedCount -Total $totalUsers
-            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$ProcessedCount out of $totalUsers - $Percentage%" -PercentComplete $Percentage
+            $processedCount++
+            $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalUsers
+            Write-Progress -Activity "Processing $($User.DisplayName)" -Status "$processedCount out of $totalUsers - $Percentage%" -PercentComplete $Percentage
 
-            if ($ProcessedUsers -contains $User.UserPrincipalName) {
+            if ($processedUsers.Contains($User.UserPrincipalName)) {
                 Write-NCMessage "Skipping $($User.UserPrincipalName), already processed." -Level WARNING
                 continue
             }
+
+            $processedSinceFlush++
 
             try {
                 $GraphLicense = Invoke-NCRetry -Action {
@@ -766,6 +1108,22 @@ function Export-MsolAccountSku {
         }
             catch {
                 Write-NCMessage "Failed to retrieve licenses for $($User.UserPrincipalName) after $maxAttempts attempts. Skipping." -Level ERROR
+                $consecutiveErrors++
+                if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                    if ($reportBuffer.Count -gt 0) {
+                        if ((Test-Path -LiteralPath $CSV) -and ((Get-Item -LiteralPath $CSV).Length -gt 0)) {
+                            $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding) -Append
+                        }
+                        else {
+                            $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding)
+                        }
+                        $reportBuffer.Clear()
+                    }
+
+                    Write-NCMessage ("Stopping export after {0} consecutive user error(s). Partial report kept at {1}." -f $consecutiveErrors, $CSV) -Level ERROR
+                    $aborted = $true
+                    break
+                }
                 continue
             }
 
@@ -843,16 +1201,42 @@ function Export-MsolAccountSku {
                 }
             }
 
-            $arr_MsolAccountSku += $userRows
+            if ($userRows.Count -gt 0) {
+                $reportBuffer.AddRange($userRows)
+                $null = $processedUsers.Add($User.UserPrincipalName)
+            }
 
-            if ($ProcessedCount % 50 -eq 0) {
-                Write-Verbose "Processed $ProcessedCount out of $totalUsers, saving partial results ..."
-                $arr_MsolAccountSku | Export-CSV $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding) -Append
+            $consecutiveErrors = 0
+
+            if ($processedSinceFlush -ge $BatchSize -and $reportBuffer.Count -gt 0) {
+                if ((Test-Path -LiteralPath $CSV) -and ((Get-Item -LiteralPath $CSV).Length -gt 0)) {
+                    $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding) -Append
+                }
+                else {
+                    $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding)
+                }
+                Write-Verbose "Processed $processedCount out of $totalUsers, saving partial results ..."
+                $reportBuffer.Clear()
+                $processedSinceFlush = 0
             }
         }
 
-        $arr_MsolAccountSku | Export-CSV $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding)
-        Write-NCMessage "User license report exported to $CSV." -Level SUCCESS
+        if ($reportBuffer.Count -gt 0) {
+            if ((Test-Path -LiteralPath $CSV) -and ((Get-Item -LiteralPath $CSV).Length -gt 0)) {
+                $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding) -Append
+            }
+            else {
+                $reportBuffer | Export-CSV -LiteralPath $CSV -NoTypeInformation -Delimiter $($NCVars.CSV_DefaultLimiter) -Encoding $($NCVars.CSV_Encoding)
+            }
+            $reportBuffer.Clear()
+        }
+
+        if ($aborted) {
+            Write-NCMessage "User license report export stopped early. Partial data kept at $CSV." -Level ERROR
+        }
+        else {
+            Write-NCMessage "User license report exported to $CSV." -Level SUCCESS
+        }
 
         if ($resolvedViaCustom.Count -gt 0) {
             Write-NCMessage "Licenses not found, but resolved via custom catalog:" -Level WARNING

--- a/Public/NC.Licenses.ps1
+++ b/Public/NC.Licenses.ps1
@@ -243,288 +243,6 @@ function Add-UserMsolAccountSku {
     }
 }
 
-function Set-UserUsageLocation {
-    <#
-    .SYNOPSIS
-        Updates usage location for one or more users.
-    .DESCRIPTION
-        Resolves users from pipeline or explicit input, connects to Microsoft Graph, and updates
-        their UsageLocation value. If -UsageLocation is omitted, Nebula.Core uses the configured
-        UsageLocation default (or US when no override exists).
-    .PARAMETER UserPrincipalName
-        User principal name, object ID, or short identifier. Accepts pipeline input.
-    .PARAMETER UsageLocation
-        Two-letter country code to set. When omitted, the configured default is used.
-    .PARAMETER PassThru
-        Emit the processed users as objects.
-    .EXAMPLE
-        Set-UserUsageLocation -UserPrincipalName user@contoso.com -UsageLocation IT
-    .EXAMPLE
-        'user1@contoso.com','user2@contoso.com' | Set-UserUsageLocation -UsageLocation DE
-    .EXAMPLE
-        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Set-UserUsageLocation -UsageLocation FR
-    #>
-    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
-    param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('User', 'UPN', 'Identity')]
-        [string[]]$UserPrincipalName,
-        [string]$UsageLocation,
-        [switch]$PassThru
-    )
-
-    begin {
-        Set-ProgressAndInfoPreferences
-        $targets = [System.Collections.Generic.List[string]]::new()
-    }
-
-    process {
-        foreach ($entry in $UserPrincipalName) {
-            if (-not [string]::IsNullOrWhiteSpace($entry)) {
-                $targets.Add($entry.Trim()) | Out-Null
-            }
-        }
-    }
-
-    end {
-        try {
-            if ($targets.Count -eq 0) {
-                Write-NCMessage "No user principal names provided." -Level WARNING
-                return
-            }
-
-            $GraphConnection = Test-MgGraphConnection -Scopes @('Directory.ReadWrite.All') -EnsureExchangeOnline:$false
-            if (-not $GraphConnection) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-
-            $defaultUsageLocation = if (-not [string]::IsNullOrWhiteSpace($UsageLocation)) {
-                $UsageLocation.Trim()
-            }
-            elseif (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
-                [string]$NCVars.UsageLocation
-            }
-            else {
-                'US'
-            }
-
-            $targetUsage = $defaultUsageLocation.Trim().ToUpperInvariant()
-            if ($targetUsage.Length -ne 2) {
-                Write-NCMessage "UsageLocation must be a two-letter country code." -Level ERROR
-                return
-            }
-
-            $normalizeUsageLocation = {
-                param($value)
-                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
-                return $value.Trim().ToUpperInvariant()
-            }
-
-            $queue = [System.Collections.Generic.List[string]]::new()
-            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-            foreach ($entry in $targets) {
-                if ($dedup.Add($entry)) {
-                    $queue.Add($entry) | Out-Null
-                }
-            }
-
-            $results = [System.Collections.Generic.List[object]]::new()
-            $updatedCount = 0
-            $skippedCount = 0
-            $counter = 0
-
-            foreach ($upn in $queue) {
-                $counter++
-                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
-                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
-
-                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
-                if (-not $resolvedPrincipal) {
-                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
-                    continue
-                }
-
-                try {
-                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
-                }
-                catch {
-                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
-                    continue
-                }
-
-                $currentUsage = & $normalizeUsageLocation $user.UsageLocation
-                if ($currentUsage -eq $targetUsage) {
-                    $skippedCount++
-                    if ($PassThru.IsPresent) {
-                        $results.Add([pscustomobject]@{
-                                UserPrincipalName     = $user.UserPrincipalName
-                                DisplayName           = $user.DisplayName
-                                PreviousUsageLocation = $user.UsageLocation
-                                UsageLocation         = $user.UsageLocation
-                                Action                = 'Skipped'
-                            }) | Out-Null
-                    }
-                    Write-Verbose "Usage location already set to $targetUsage for $($user.UserPrincipalName)."
-                    continue
-                }
-
-                if (-not $PSCmdlet.ShouldProcess($user.UserPrincipalName, "Set usage location to $targetUsage")) {
-                    continue
-                }
-
-                try {
-                    Update-MgUser -UserId $user.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
-                    $updatedCount++
-                    if ($PassThru.IsPresent) {
-                        $results.Add([pscustomobject]@{
-                                UserPrincipalName     = $user.UserPrincipalName
-                                DisplayName           = $user.DisplayName
-                                PreviousUsageLocation = $user.UsageLocation
-                                UsageLocation         = $targetUsage
-                                Action                = 'Updated'
-                            }) | Out-Null
-                    }
-                    Write-Verbose "Usage location set to $targetUsage for $($user.UserPrincipalName)."
-                }
-                catch {
-                    Write-NCMessage "Unable to set usage location ($targetUsage) for $($user.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
-                }
-            }
-
-            if ($PassThru.IsPresent) {
-                $results
-            }
-            elseif ($updatedCount -gt 0) {
-                $summary = "Usage location updated for {0} user(s) to {1}." -f $updatedCount, $targetUsage
-                if ($skippedCount -gt 0) {
-                    $summary = $summary + (" {0} user(s) already had that value." -f $skippedCount)
-                }
-                Write-NCMessage $summary -Level SUCCESS
-            }
-            elseif ($skippedCount -gt 0) {
-                Write-NCMessage ("Usage location already set to {0} for {1} user(s)." -f $targetUsage, $skippedCount) -Level INFO
-            }
-            else {
-                Write-NCMessage "No usage location changes were applied." -Level WARNING
-            }
-        }
-        finally {
-            Write-Progress -Activity "Processing users" -Completed
-            Restore-ProgressAndInfoPreferences
-        }
-    }
-}
-
-function Get-UserUsageLocation {
-    <#
-    .SYNOPSIS
-        Reads the current usage location for one or more users.
-    .DESCRIPTION
-        Resolves users from pipeline or explicit input and returns their current UsageLocation
-        from Microsoft Graph. The output also includes the configured NebulaCore default so the
-        current value can be compared against the environment setting at a glance.
-    .PARAMETER UserPrincipalName
-        User principal name, object ID, or short identifier. Accepts pipeline input.
-    .EXAMPLE
-        Get-UserUsageLocation -UserPrincipalName user@contoso.com
-    .EXAMPLE
-        'user1@contoso.com','user2@contoso.com' | Get-UserUsageLocation
-    .EXAMPLE
-        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Get-UserUsageLocation
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('User', 'UPN', 'Identity')]
-        [string[]]$UserPrincipalName
-    )
-
-    begin {
-        Set-ProgressAndInfoPreferences
-        $targets = [System.Collections.Generic.List[string]]::new()
-    }
-
-    process {
-        foreach ($entry in $UserPrincipalName) {
-            if (-not [string]::IsNullOrWhiteSpace($entry)) {
-                $targets.Add($entry.Trim()) | Out-Null
-            }
-        }
-    }
-
-    end {
-        try {
-            if ($targets.Count -eq 0) {
-                Write-NCMessage "No user principal names provided." -Level WARNING
-                return
-            }
-
-            $GraphConnection = Test-MgGraphConnection -Scopes @('User.Read.All') -EnsureExchangeOnline:$false
-            if (-not $GraphConnection) {
-                Add-EmptyLine
-                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
-                return
-            }
-
-            $defaultUsageLocation = if (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
-                [string]$NCVars.UsageLocation
-            }
-            else {
-                'US'
-            }
-
-            $normalizeUsageLocation = {
-                param($value)
-                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
-                return $value.Trim().ToUpperInvariant()
-            }
-
-            $queue = [System.Collections.Generic.List[string]]::new()
-            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-            foreach ($entry in $targets) {
-                if ($dedup.Add($entry)) {
-                    $queue.Add($entry) | Out-Null
-                }
-            }
-
-            $counter = 0
-            foreach ($upn in $queue) {
-                $counter++
-                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
-                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
-
-                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
-                if (-not $resolvedPrincipal) {
-                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
-                    continue
-                }
-
-                try {
-                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
-                }
-                catch {
-                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
-                    continue
-                }
-
-                [pscustomobject]@{
-                    UserPrincipalName                = $user.UserPrincipalName
-                    DisplayName                      = $user.DisplayName
-                    UsageLocation                    = $user.UsageLocation
-                    ConfiguredDefaultUsageLocation   = $defaultUsageLocation
-                    MatchesConfiguredDefault         = (& $normalizeUsageLocation $user.UsageLocation) -eq (& $normalizeUsageLocation $defaultUsageLocation)
-                }
-            }
-        }
-        finally {
-            Write-Progress -Activity "Processing users" -Completed
-            Restore-ProgressAndInfoPreferences
-        }
-    }
-}
-
 function Copy-UserMsolAccountSku {
     <#
     .SYNOPSIS
@@ -1191,14 +909,14 @@ function Export-MsolAccountSku {
 
             if ($License -and $userMatchedLicenseNames.Count -gt 0) {
                 $matchedNames = $userMatchedLicenseNames | Select-Object -Unique
-                $userRows = $userRows | ForEach-Object {
+                $userRows = @($userRows | ForEach-Object {
                     $_ | Add-Member -NotePropertyName MatchedLicenses -NotePropertyValue ($matchedNames -join ', ') -PassThru
-                }
+                })
             }
             elseif ($License) {
-                $userRows = $userRows | ForEach-Object {
+                $userRows = @($userRows | ForEach-Object {
                     $_ | Add-Member -NotePropertyName MatchedLicenses -NotePropertyValue $null -PassThru
-                }
+                })
             }
 
             if ($userRows.Count -gt 0) {
@@ -1476,18 +1194,18 @@ function Get-TenantMsolAccountSku {
                             Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
                                 -All `
                                 -ConsistencyLevel eventual `
-                                -Property Id,UserPrincipalName,DisplayName,Mail,ProxyAddresses `
+                                -Property Id, UserPrincipalName, DisplayName, Mail, ProxyAddresses `
                                 -ErrorAction Stop |
-                                Where-Object { & $matchesDomain $_ } |
-                                Select-Object -First $sampleUserLimit
+                            Where-Object { & $matchesDomain $_ } |
+                            Select-Object -First $sampleUserLimit
                         }
                         else {
                             Get-MgUser -Filter "assignedLicenses/any(x:x/skuId eq $($sku.SkuId))" `
                                 -Top $sampleUserLimit `
                                 -ConsistencyLevel eventual `
-                                -Property Id,UserPrincipalName,DisplayName `
+                                -Property Id, UserPrincipalName, DisplayName `
                                 -ErrorAction Stop |
-                                Select-Object -First $sampleUserLimit
+                            Select-Object -First $sampleUserLimit
                         }
                     } -MaxAttempts $maxAttempts -DelaySeconds 5 -OperationDescription "retrieve sample users for $($sku.SkuPartNumber)" -OnError {
                         param($attempt, $max, $err)
@@ -1515,18 +1233,18 @@ function Get-TenantMsolAccountSku {
                 }
 
                 [pscustomobject][ordered]@{
-                    Name          = $sku.Name
-                    SkuPartNumber = $sku.SkuPartNumber
-                    SkuId         = $sku.SkuId
-                    Total         = $sku.Total
-                    TotalCount    = $sku.TotalCount
-                    Consumed      = $sku.Consumed
-                    Available     = $sku.Available
-                    Enabled       = $sku.Enabled
-                    Suspended     = $sku.Suspended
-                    Warning       = $sku.Warning
-                    Source        = $sku.Source
-                    SampleUsers   = $sampleUserList
+                    Name            = $sku.Name
+                    SkuPartNumber   = $sku.SkuPartNumber
+                    SkuId           = $sku.SkuId
+                    Total           = $sku.Total
+                    TotalCount      = $sku.TotalCount
+                    Consumed        = $sku.Consumed
+                    Available       = $sku.Available
+                    Enabled         = $sku.Enabled
+                    Suspended       = $sku.Suspended
+                    Warning         = $sku.Warning
+                    Source          = $sku.Source
+                    SampleUsers     = $sampleUserList
                     SampleUsersText = if ($sampleUserList.Count -gt 0) { $sampleUserList -join [Environment]::NewLine } else { $null }
                 }
             }
@@ -1556,9 +1274,9 @@ function Get-TenantMsolAccountSku {
         }
         elseif ($AsTable.IsPresent) {
             $limited = $sorted | Select-Object @{
-                    Name       = 'Name'
-                    Expression = { Format-OutputString -Value $_.Name -MaxLength $NCVars.MaxFieldLength }
-                }, SkuPartNumber, Total, Consumed, Available
+                Name       = 'Name'
+                Expression = { Format-OutputString -Value $_.Name -MaxLength $NCVars.MaxFieldLength }
+            }, SkuPartNumber, Total, Consumed, Available
             Show-Table -Rows $limited -AsTable
 
             if ($useSampleUsers) {
@@ -1812,6 +1530,114 @@ function Get-UserMsolAccountSku {
     }
 }
 
+function Get-UserUsageLocation {
+    <#
+    .SYNOPSIS
+        Reads the current usage location for one or more users.
+    .DESCRIPTION
+        Resolves users from pipeline or explicit input and returns their current UsageLocation
+        from Microsoft Graph. The output also includes the configured NebulaCore default so the
+        current value can be compared against the environment setting at a glance.
+    .PARAMETER UserPrincipalName
+        User principal name, object ID, or short identifier. Accepts pipeline input.
+    .EXAMPLE
+        Get-UserUsageLocation -UserPrincipalName user@contoso.com
+    .EXAMPLE
+        'user1@contoso.com','user2@contoso.com' | Get-UserUsageLocation
+    .EXAMPLE
+        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Get-UserUsageLocation
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'UPN', 'Identity')]
+        [string[]]$UserPrincipalName
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $UserPrincipalName) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if ($targets.Count -eq 0) {
+                Write-NCMessage "No user principal names provided." -Level WARNING
+                return
+            }
+
+            $GraphConnection = Test-MgGraphConnection -Scopes @('User.Read.All') -EnsureExchangeOnline:$false
+            if (-not $GraphConnection) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $defaultUsageLocation = if (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
+                [string]$NCVars.UsageLocation
+            }
+            else {
+                'US'
+            }
+
+            $normalizeUsageLocation = {
+                param($value)
+                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
+                return $value.Trim().ToUpperInvariant()
+            }
+
+            $queue = [System.Collections.Generic.List[string]]::new()
+            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($entry in $targets) {
+                if ($dedup.Add($entry)) {
+                    $queue.Add($entry) | Out-Null
+                }
+            }
+
+            $counter = 0
+            foreach ($upn in $queue) {
+                $counter++
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
+
+                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
+                if (-not $resolvedPrincipal) {
+                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
+                    continue
+                }
+
+                try {
+                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id, UserPrincipalName, DisplayName, UsageLocation -ErrorAction Stop
+                }
+                catch {
+                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
+                    continue
+                }
+
+                [pscustomobject]@{
+                    UserPrincipalName              = $user.UserPrincipalName
+                    DisplayName                    = $user.DisplayName
+                    UsageLocation                  = $user.UsageLocation
+                    ConfiguredDefaultUsageLocation = $defaultUsageLocation
+                    MatchesConfiguredDefault       = (& $normalizeUsageLocation $user.UsageLocation) -eq (& $normalizeUsageLocation $defaultUsageLocation)
+                }
+            }
+        }
+        finally {
+            Write-Progress -Activity "Processing users" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
 function Move-UserMsolAccountSku {
     <#
     .SYNOPSIS
@@ -1862,8 +1688,8 @@ function Move-UserMsolAccountSku {
         }
 
         try {
-            $sourceUser = Get-MgUser -UserId $resolvedSource -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
-            $destinationUser = Get-MgUser -UserId $resolvedDestination -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
+            $sourceUser = Get-MgUser -UserId $resolvedSource -Property Id, UserPrincipalName, DisplayName, UsageLocation -ErrorAction Stop
+            $destinationUser = Get-MgUser -UserId $resolvedDestination -Property Id, UserPrincipalName, DisplayName, UsageLocation -ErrorAction Stop
         }
         catch {
             Write-NCMessage "Unable to retrieve users: $($_.Exception.Message)" -Level ERROR
@@ -2279,6 +2105,180 @@ function Remove-UserMsolAccountSku {
 
     end {
         Restore-ProgressAndInfoPreferences
+    }
+}
+
+function Set-UserUsageLocation {
+    <#
+    .SYNOPSIS
+        Updates usage location for one or more users.
+    .DESCRIPTION
+        Resolves users from pipeline or explicit input, connects to Microsoft Graph, and updates
+        their UsageLocation value. If -UsageLocation is omitted, Nebula.Core uses the configured
+        UsageLocation default (or US when no override exists).
+    .PARAMETER UserPrincipalName
+        User principal name, object ID, or short identifier. Accepts pipeline input.
+    .PARAMETER UsageLocation
+        Two-letter country code to set. When omitted, the configured default is used.
+    .PARAMETER PassThru
+        Emit the processed users as objects.
+    .EXAMPLE
+        Set-UserUsageLocation -UserPrincipalName user@contoso.com -UsageLocation IT
+    .EXAMPLE
+        'user1@contoso.com','user2@contoso.com' | Set-UserUsageLocation -UsageLocation DE
+    .EXAMPLE
+        Get-MgUser -Filter "endsWith(userPrincipalName,'@contoso.com')" | Set-UserUsageLocation -UsageLocation FR
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('User', 'UPN', 'Identity')]
+        [string[]]$UserPrincipalName,
+        [string]$UsageLocation,
+        [switch]$PassThru
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $UserPrincipalName) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if ($targets.Count -eq 0) {
+                Write-NCMessage "No user principal names provided." -Level WARNING
+                return
+            }
+
+            $GraphConnection = Test-MgGraphConnection -Scopes @('Directory.ReadWrite.All') -EnsureExchangeOnline:$false
+            if (-not $GraphConnection) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Graph modules. Please check logs." -Level ERROR
+                return
+            }
+
+            $defaultUsageLocation = if (-not [string]::IsNullOrWhiteSpace($UsageLocation)) {
+                $UsageLocation.Trim()
+            }
+            elseif (($NCVars -is [System.Collections.IDictionary]) -and $NCVars.Contains('UsageLocation') -and $NCVars.UsageLocation) {
+                [string]$NCVars.UsageLocation
+            }
+            else {
+                'US'
+            }
+
+            $targetUsage = $defaultUsageLocation.Trim().ToUpperInvariant()
+            if ($targetUsage.Length -ne 2) {
+                Write-NCMessage "UsageLocation must be a two-letter country code." -Level ERROR
+                return
+            }
+
+            $normalizeUsageLocation = {
+                param($value)
+                if ([string]::IsNullOrWhiteSpace($value)) { return $null }
+                return $value.Trim().ToUpperInvariant()
+            }
+
+            $queue = [System.Collections.Generic.List[string]]::new()
+            $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($entry in $targets) {
+                if ($dedup.Add($entry)) {
+                    $queue.Add($entry) | Out-Null
+                }
+            }
+
+            $results = [System.Collections.Generic.List[object]]::new()
+            $updatedCount = 0
+            $skippedCount = 0
+            $counter = 0
+
+            foreach ($upn in $queue) {
+                $counter++
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
+                Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
+
+                $resolvedPrincipal = Find-UserRecipient -UserPrincipalName $upn -PreferGraphIdentity
+                if (-not $resolvedPrincipal) {
+                    Write-NCMessage "Unable to resolve user recipient for $upn" -Level ERROR
+                    continue
+                }
+
+                try {
+                    $user = Get-MgUser -UserId $resolvedPrincipal -Property Id,UserPrincipalName,DisplayName,UsageLocation -ErrorAction Stop
+                }
+                catch {
+                    Write-NCMessage "Unable to retrieve user '$upn'. $($_.Exception.Message)" -Level ERROR
+                    continue
+                }
+
+                $currentUsage = & $normalizeUsageLocation $user.UsageLocation
+                if ($currentUsage -eq $targetUsage) {
+                    $skippedCount++
+                    if ($PassThru.IsPresent) {
+                        $results.Add([pscustomobject]@{
+                                UserPrincipalName     = $user.UserPrincipalName
+                                DisplayName           = $user.DisplayName
+                                PreviousUsageLocation = $user.UsageLocation
+                                UsageLocation         = $user.UsageLocation
+                                Action                = 'Skipped'
+                            }) | Out-Null
+                    }
+                    Write-Verbose "Usage location already set to $targetUsage for $($user.UserPrincipalName)."
+                    continue
+                }
+
+                if (-not $PSCmdlet.ShouldProcess($user.UserPrincipalName, "Set usage location to $targetUsage")) {
+                    continue
+                }
+
+                try {
+                    Update-MgUser -UserId $user.Id -UsageLocation $targetUsage -ErrorAction Stop | Out-Null
+                    $updatedCount++
+                    if ($PassThru.IsPresent) {
+                        $results.Add([pscustomobject]@{
+                                UserPrincipalName     = $user.UserPrincipalName
+                                DisplayName           = $user.DisplayName
+                                PreviousUsageLocation = $user.UsageLocation
+                                UsageLocation         = $targetUsage
+                                Action                = 'Updated'
+                            }) | Out-Null
+                    }
+                    Write-Verbose "Usage location set to $targetUsage for $($user.UserPrincipalName)."
+                }
+                catch {
+                    Write-NCMessage "Unable to set usage location ($targetUsage) for $($user.UserPrincipalName): $($_.Exception.Message)" -Level ERROR
+                }
+            }
+
+            if ($PassThru.IsPresent) {
+                $results
+            }
+            elseif ($updatedCount -gt 0) {
+                $summary = "Usage location updated for {0} user(s) to {1}." -f $updatedCount, $targetUsage
+                if ($skippedCount -gt 0) {
+                    $summary = $summary + (" {0} user(s) already had that value." -f $skippedCount)
+                }
+                Write-NCMessage $summary -Level SUCCESS
+            }
+            elseif ($skippedCount -gt 0) {
+                Write-NCMessage ("Usage location already set to {0} for {1} user(s)." -f $targetUsage, $skippedCount) -Level INFO
+            }
+            else {
+                Write-NCMessage "No usage location changes were applied." -Level WARNING
+            }
+        }
+        finally {
+            Write-Progress -Activity "Processing users" -Completed
+            Restore-ProgressAndInfoPreferences
+        }
     }
 }
 

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -240,121 +240,6 @@ function Add-MboxPermission {
     end { Restore-ProgressAndInfoPreferences }
 }
 
-function Export-MboxAlias {
-    <#
-    .SYNOPSIS
-        Exports aliases for one or more recipients.
-    .DESCRIPTION
-        Enumerates aliases for specified mailboxes, all mailboxes, or recipients filtered by domain,
-        and optionally writes them to a CSV file.
-    .PARAMETER SourceMailbox
-        Mailbox identities to analyze.
-    .PARAMETER Csv
-        Export the results to CSV.
-    .PARAMETER CsvFolder
-        Destination folder for the CSV file. Defaults to current directory.
-    .PARAMETER All
-        Export aliases for every non-guest recipient.
-    .PARAMETER Domain
-        Export aliases for recipients whose addresses match the provided domain.
-    .EXAMPLE
-        Export-MboxAlias -SourceMailbox user@contoso.com
-    .EXAMPLE
-        Export-MboxAlias -All -CsvFolder C:\Temp
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-        [Alias('Identity')]
-        [string[]]$SourceMailbox,
-        [switch]$Csv,
-        [string]$CsvFolder,
-        [switch]$All,
-        [string]$Domain
-    )
-
-    begin {
-        Set-ProgressAndInfoPreferences
-        $aliases = [System.Collections.Generic.List[object]]::new()
-    }
-
-    process {
-        if (-not (Test-EOLConnection)) {
-            Add-EmptyLine
-            Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
-            return
-        }
-
-        if ((-not $SourceMailbox -or $SourceMailbox.Count -eq 0) -and -not $All -and [string]::IsNullOrWhiteSpace($Domain)) {
-            $All = $true
-        }
-
-        if (-not [string]::IsNullOrWhiteSpace($Domain)) {
-            $SourceMailbox = Get-Recipient -ResultSize Unlimited | Where-Object { $_.RecipientTypeDetails -ne 'GuestMailUser' -and $_.EmailAddresses -like "*@$Domain" }
-            $Csv = $true
-        }
-
-        if ($All) {
-            Write-NCMessage "No mailbox specified; scanning all recipients. This may take a while." -Level WARNING
-            $SourceMailbox = Get-Recipient -ResultSize Unlimited | Where-Object { $_.RecipientTypeDetails -ne 'GuestMailUser' }
-            $Csv = $true
-        }
-
-        if ($Csv -and -not $script:ExportMboxAliasFolder) {
-            try {
-                $script:ExportMboxAliasFolder = Test-Folder $CsvFolder
-            }
-            catch {
-                Write-NCMessage "Invalid CSV folder. $($_.Exception.Message)" -Level ERROR
-                return
-            }
-        }
-
-        $counter = 0
-        $total = $SourceMailbox.Count
-        foreach ($entry in $SourceMailbox) {
-            try {
-                $recipient = Get-Recipient -Identity $entry -ErrorAction Stop
-            }
-            catch {
-                Write-NCMessage "Recipient '$entry' not found. $($_.Exception.Message)" -Level WARNING
-                continue
-            }
-
-            $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
-            Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
-
-            $primary = $recipient.PrimarySmtpAddress
-            foreach ($address in $recipient.EmailAddresses | Where-Object { $_ -clike 'smtp*' }) {
-                $aliases.Add([pscustomobject]@{
-                        PrimarySmtpAddress = $primary
-                        Alias              = $address.ToString().Substring(5)
-                    }) | Out-Null
-            }
-        }
-    }
-
-    end {
-        try {
-            if ($Csv) {
-                $folder = if ($script:ExportMboxAliasFolder) { $script:ExportMboxAliasFolder } else { Test-Folder $CsvFolder }
-                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-Alias-Report.csv"
-                $aliases | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-                Write-NCMessage "Alias report exported to $csvPath" -Level SUCCESS
-                $csvPath
-            }
-            else {
-                $aliases
-            }
-        }
-        finally {
-            Write-Progress -Activity "Processing aliases" -Completed
-            Restore-ProgressAndInfoPreferences
-        }
-    }
-}
-
 function Export-MboxPermission {
     <#
     .SYNOPSIS
@@ -402,7 +287,7 @@ function Export-MboxPermission {
         $counter = 0
         foreach ($mailbox in $mailboxes) {
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $mailboxes.Count
             Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) - $Percentage%" -PercentComplete $Percentage
 
             $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity
@@ -426,7 +311,6 @@ function Export-MboxPermission {
             $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-MboxPermissions-Report.csv"
             $permissions | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
             Write-NCMessage "Mailbox permissions exported to $csvPath" -Level SUCCESS
-            $csvPath
         }
         finally {
             Write-Progress -Activity "Processing mailbox permissions" -Completed
@@ -441,19 +325,65 @@ function Get-MboxAlias {
         Lists primary and secondary SMTP addresses for a recipient.
     .DESCRIPTION
         Ensures Exchange Online connectivity and returns aliases with a flag for the primary address.
+        Use -Csv for single mailbox exports.
+        Use -All or -Domain to export a tenant-wide or domain-scoped CSV report with one row per alias.
+        CSV exports include DisplayName and Name, omit recipients that have only the primary address unless -IncludePrimaryOnly is used,
+        and hide MOERA addresses unless -IncludeMoera is used.
     .PARAMETER SourceMailbox
         Mailbox or recipient identity. Accepts pipeline input.
+    .PARAMETER Csv
+        Export a single mailbox result set to CSV.
+    .PARAMETER CsvFolder
+        Destination folder for the CSV file. Defaults to current directory.
+    .PARAMETER All
+        Enumerate every non-guest recipient and export the aliases to CSV.
+    .PARAMETER Domain
+        Enumerate recipients whose addresses match the provided domain and export the aliases to CSV.
+    .PARAMETER IncludePrimaryOnly
+        Include recipients that have no secondary aliases in CSV exports.
+    .PARAMETER IncludeMoera
+        Include MOERA addresses in CSV exports.
     .EXAMPLE
         Get-MboxAlias -SourceMailbox user@contoso.com
+    .EXAMPLE
+        Get-MboxAlias user@contoso.com
+    .EXAMPLE
+        Get-MboxAlias -All -CsvFolder C:\Temp
+    .EXAMPLE
+        Get-MboxAlias -SourceMailbox user@contoso.com -Csv -IncludeMoera -CsvFolder C:\Temp
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'Single')]
         [Alias('Identity')]
-        [string]$SourceMailbox
+        [string]$SourceMailbox,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [switch]$Csv,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [string]$CsvFolder,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [switch]$IncludePrimaryOnly,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [switch]$IncludeMoera,
+        [Parameter(Mandatory, ParameterSetName = 'All')]
+        [switch]$All,
+        [Parameter(Mandatory, ParameterSetName = 'Domain')]
+        [string]$Domain
     )
 
-    begin { Set-ProgressAndInfoPreferences }
+    begin {
+        Set-ProgressAndInfoPreferences
+        $aliasRows = [System.Collections.Generic.List[object]]::new()
+        $resolvedCsvFolder = $null
+    }
 
     process {
         if (-not (Test-EOLConnection)) {
@@ -462,41 +392,184 @@ function Get-MboxAlias {
             return
         }
 
-        try {
-            $recipient = Get-Recipient -Identity $SourceMailbox -ErrorAction Stop
+        if ($PSCmdlet.ParameterSetName -eq 'Single') {
+            try {
+                $recipient = Get-Recipient -Identity $SourceMailbox -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Recipient '$SourceMailbox' not available or not found." -Level ERROR
+                return
+            }
+
+            $recipients = @($recipient)
         }
-        catch {
-            Write-NCMessage "Recipient '$SourceMailbox' not available or not found." -Level ERROR
+        else {
+            if ($All) {
+                Write-NCMessage "No mailbox specified; scanning all recipients. This may take a while." -Level WARNING
+                Write-Progress -Activity "Processing aliases" -Status "Retrieving recipient list ..." -PercentComplete 0
+                $recipients = Get-Recipient -ResultSize Unlimited | Where-Object { $_.RecipientTypeDetails -ne 'GuestMailUser' }
+                Write-Progress -Activity "Processing aliases" -Status "Recipient list loaded." -PercentComplete 5
+            }
+            else {
+                $normalizedDomain = $Domain.Trim().ToLowerInvariant().TrimStart('@')
+                if ([string]::IsNullOrWhiteSpace($normalizedDomain)) {
+                    Write-NCMessage "Domain filter cannot be empty." -Level ERROR
+                    return
+                }
+
+                Write-Progress -Activity "Processing aliases" -Status "Retrieving recipient list for domain '$normalizedDomain' ..." -PercentComplete 0
+                $recipients = Get-Recipient -ResultSize Unlimited | Where-Object {
+                    $_.RecipientTypeDetails -ne 'GuestMailUser' -and $_.EmailAddresses -like "*@$normalizedDomain"
+                }
+                Write-Progress -Activity "Processing aliases" -Status "Recipient list loaded." -PercentComplete 5
+            }
+        }
+
+        $willExport = $Csv -or $PSCmdlet.ParameterSetName -ne 'Single'
+
+        if ($willExport -and -not $resolvedCsvFolder) {
+            try {
+                $resolvedCsvFolder = Test-Folder $CsvFolder
+            }
+            catch {
+                Write-NCMessage "Invalid CSV folder. $($_.Exception.Message)" -Level ERROR
+                return
+            }
+        }
+
+        $recipientCount = @($recipients).Count
+        $addressCount = 0
+        foreach ($recipient in $recipients) {
+            $addressCount += @($recipient.EmailAddresses).Count
+        }
+
+        $baseProgress = if ($PSCmdlet.ParameterSetName -eq 'Single') { 0 } else { 5 }
+        $progressSpan = if ($willExport) { 94 } else { 95 }
+        $totalWorkUnits = [Math]::Max($recipientCount + $addressCount, 1)
+        $completedWorkUnits = 0
+        $recipientIndex = 0
+        $updateAliasProgress = {
+            param(
+                [string]$Status,
+                [switch]$Advance
+            )
+
+            if ($Advance) {
+                $completedWorkUnits++
+            }
+
+            $percentage = [Math]::Min(99, [Math]::Round($baseProgress + (($completedWorkUnits / $totalWorkUnits) * $progressSpan), 2))
+            Write-Progress -Activity "Processing aliases" -Status $Status -PercentComplete $percentage
+        }
+
+        foreach ($recipient in $recipients) {
+            $recipientIndex++
+            & $updateAliasProgress -Status "Recipient $recipientIndex of $recipientCount" -Advance
+
+            $rows = [System.Collections.Generic.List[object]]::new()
+            foreach ($address in $recipient.EmailAddresses) {
+                & $updateAliasProgress -Status "Recipient $recipientIndex of $recipientCount" -Advance
+
+                if ($address -clike 'SMTP:*') {
+                    if ($willExport) {
+                        $rows.Add([pscustomobject]@{
+                                DisplayName        = $recipient.DisplayName
+                                Name               = $recipient.Name
+                                PrimarySmtpAddress = $recipient.PrimarySmtpAddress
+                                Alias              = $address.Replace('SMTP:', '')
+                                IsPrimary          = $true
+                                IsMoera            = $address.Replace('SMTP:', '') -match '@[^@]+\.onmicrosoft\.com$'
+                            }) | Out-Null
+                    }
+                    else {
+                        $rows.Add([pscustomobject]@{
+                                PrimarySmtpAddress = $recipient.PrimarySmtpAddress
+                                Alias              = $address.Replace('SMTP:', '')
+                                IsPrimary          = $true
+                            }) | Out-Null
+                    }
+                }
+                elseif ($address -clike 'smtp:*') {
+                    if ($willExport) {
+                        $rows.Add([pscustomobject]@{
+                                DisplayName        = $recipient.DisplayName
+                                Name               = $recipient.Name
+                                PrimarySmtpAddress = $recipient.PrimarySmtpAddress
+                                Alias              = $address.Replace('smtp:', '')
+                                IsPrimary          = $false
+                                IsMoera            = $address.Replace('smtp:', '') -match '@[^@]+\.onmicrosoft\.com$'
+                            }) | Out-Null
+                    }
+                    else {
+                        $rows.Add([pscustomobject]@{
+                                PrimarySmtpAddress = $recipient.PrimarySmtpAddress
+                                Alias              = $address.Replace('smtp:', '')
+                                IsPrimary          = $false
+                            }) | Out-Null
+                    }
+                }
+            }
+
+            if ($rows.Count -eq 0) {
+                Write-NCMessage "No aliases found for '$($recipient.PrimarySmtpAddress)'." -Level WARNING
+                continue
+            }
+
+            if ($willExport) {
+                $exportRows = $rows
+                if (-not $IncludeMoera) {
+                    $exportRows = @($exportRows | Where-Object { -not $_.IsMoera })
+                }
+
+                if ($exportRows.Count -eq 0) {
+                    continue
+                }
+
+                if (-not $IncludePrimaryOnly -and $exportRows.Count -eq 1 -and $exportRows[0].IsPrimary -and $exportRows[0].Alias -eq $exportRows[0].PrimarySmtpAddress) {
+                    continue
+                }
+
+                $aliasRows.AddRange($exportRows)
+            }
+            else {
+                $aliasRows.AddRange($rows)
+            }
+        }
+
+        if ($aliasRows.Count -eq 0) {
+            if ($willExport -and -not $IncludePrimaryOnly) {
+                Write-NCMessage "No secondary aliases found. Use -IncludePrimaryOnly to include recipients that only have a primary SMTP address." -Level WARNING
+            }
             return
         }
 
-        $aliases = [System.Collections.Generic.List[object]]::new()
-        foreach ($address in $recipient.EmailAddresses) {
-            if ($address -clike 'SMTP:*') {
-                $aliases.Add([pscustomobject]@{
-                        PrimarySmtpAddress = $recipient.PrimarySmtpAddress
-                        Alias              = $address.Replace('SMTP:', '')
-                        IsPrimary          = $true
-                    }) | Out-Null
-            }
-            elseif ($address -clike 'smtp:*') {
-                $aliases.Add([pscustomobject]@{
-                        PrimarySmtpAddress = $recipient.PrimarySmtpAddress
-                        Alias              = $address.Replace('smtp:', '')
-                        IsPrimary          = $false
-                    }) | Out-Null
-            }
-        }
+        $sortedAliases = $aliasRows | Sort-Object -Property PrimarySmtpAddress, @{ Expression = 'IsPrimary'; Descending = $true }, Alias
 
-        if ($aliases.Count -eq 0) {
-            Write-NCMessage "No aliases found for '$($recipient.PrimarySmtpAddress)'." -Level WARNING
+        if ($willExport) {
+            & $updateAliasProgress -Status "Writing CSV export ..." -Advance
+            $exportAliases = $sortedAliases
+
+            if ($exportAliases.Count -eq 0) {
+                Write-NCMessage "No exportable aliases found. Use -IncludeMoera to include MOERA addresses or -IncludePrimaryOnly to include recipients with only a primary SMTP address." -Level WARNING
+                return
+            }
+
+            $folder = if ($resolvedCsvFolder) { $resolvedCsvFolder } else { Test-Folder $CsvFolder }
+            $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-Alias-Report.csv"
+            $exportAliases |
+                Select-Object DisplayName, Name, PrimarySmtpAddress, Alias, IsPrimary |
+                Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+            Write-NCMessage "Alias report exported to $csvPath" -Level SUCCESS
         }
         else {
-            $aliases | Sort-Object -Property @{ Expression = 'IsPrimary'; Descending = $true }, Alias
+            $sortedAliases
         }
     }
 
-    end { Restore-ProgressAndInfoPreferences }
+    end {
+        Write-Progress -Activity "Processing aliases" -Completed
+        Restore-ProgressAndInfoPreferences
+    }
 }
 
 function Get-MboxPrimarySmtpAddress {
@@ -1212,7 +1285,7 @@ function Set-MboxLanguage {
             if (-not $address) { continue }
 
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($total, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $total
             Write-Progress -Activity "Changing language to $Language" -Status "$counter of $total - $Percentage%" -PercentComplete $Percentage
 
             try {
@@ -1277,7 +1350,7 @@ function Set-MboxRulesQuota {
             }
 
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $SourceMailbox.Count
             Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) - $Percentage%" -PercentComplete $Percentage
 
             try {
@@ -1342,7 +1415,7 @@ function Set-SharedMboxCopyForSent {
                 }
 
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($SourceMailbox.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $SourceMailbox.Count
                 Write-Progress -Activity "Processing $($recipient.PrimarySmtpAddress)" -Status "$counter of $($SourceMailbox.Count) - $Percentage%" -PercentComplete $Percentage
 
                 Set-Mailbox -Identity $recipient.PrimarySmtpAddress -MessageCopyForSentAsEnabled $true
@@ -1421,7 +1494,7 @@ function Test-SharedMailboxCompliance {
 
         foreach ($mbx in $mailboxes) {
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($mailboxes.Count, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $mailboxes.Count
             Write-Progress -Activity "Checking $($mbx.DisplayName)" -Status "$counter of $($mailboxes.Count) - $Percentage%" -PercentComplete $Percentage
 
             $logsFound = $false
@@ -1481,3 +1554,5 @@ function Test-SharedMailboxCompliance {
 
     end { Restore-ProgressAndInfoPreferences }
 }
+
+

--- a/Public/NC.Mailboxes.ps1
+++ b/Public/NC.Mailboxes.ps1
@@ -251,6 +251,14 @@ function Export-MboxPermission {
         Recipient type to analyze: User, Shared, Room, All.
     .PARAMETER CsvFolder
         Destination folder for the CSV file. Defaults to current directory.
+    .PARAMETER BatchSize
+        Number of processed mailboxes before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive mailbox-level failures.
     .EXAMPLE
         Export-MboxPermission -RecipientType All -CsvFolder C:\Temp
     #>
@@ -259,12 +267,21 @@ function Export-MboxPermission {
         [Parameter(Mandatory)]
         [ValidateSet('User', 'Shared', 'Room', 'All')]
         [string]$RecipientType,
-        [string]$CsvFolder
+        [string]$CsvFolder,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     begin {
         Set-ProgressAndInfoPreferences
         $permissions = [System.Collections.Generic.List[object]]::new()
+        $processedSinceFlush = 0
+        $consecutiveErrors = 0
+        $aborted = $false
     }
 
     process {
@@ -284,33 +301,149 @@ function Export-MboxPermission {
             }
         }
 
+        $normalizeText = {
+            param($value)
+            return Get-NormalizedText -Value $value
+        }
+        $buildPermissionKey = {
+            param($row)
+
+            $mailbox = & $normalizeText $row.'Mailbox Address'
+            if (-not $mailbox) {
+                $mailbox = & $normalizeText $row.Mailbox
+            }
+            $recipientType = & $normalizeText $row.'Recipient Type'
+            return "{0}|{1}" -f $mailbox, $recipientType
+        }
+        $existingPermissionKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $csvPathResolved = $null
+        $folderForExport = Test-Folder $CsvFolder
+        $defaultCsvPath = New-File "$folderForExport\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-MboxPermissions-Report.csv"
+        $csvPathResolved = $defaultCsvPath
+
+        if ($Resume) {
+            $resumePath = $null
+            if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                $resumePath = $CsvPath
+            }
+            else {
+                $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-MboxPermissions-Report.csv" |
+                    Sort-Object LastWriteTime -Descending |
+                    Select-Object -First 1
+                if ($existingCsv) {
+                    $resumePath = $existingCsv.FullName
+                }
+            }
+
+            if ($resumePath) {
+                $csvPathResolved = $resumePath
+                if (Test-Path -LiteralPath $csvPathResolved) {
+                    try {
+                        foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                            $null = $existingPermissionKeys.Add((& $buildPermissionKey $row))
+                        }
+                        Write-NCMessage ("Resuming mailbox permissions export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingPermissionKeys.Count) -Level INFO
+                    }
+                    catch {
+                        Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                        $existingPermissionKeys.Clear()
+                        $csvPathResolved = $defaultCsvPath
+                    }
+                }
+                else {
+                    Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                }
+            }
+            else {
+                Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+            }
+        }
+
+        Write-NCMessage ("Mailbox permission export will flush every {0} mailbox(es). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+        Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+
+        $writeBuffer = {
+            param([System.Collections.Generic.List[object]]$buffer)
+
+            if ($buffer.Count -eq 0) {
+                return
+            }
+
+            $exportRows = $buffer
+            if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+            }
+            else {
+                $exportRows | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+            }
+            $buffer.Clear()
+        }
+
         $counter = 0
         foreach ($mailbox in $mailboxes) {
             $counter++
             $Percentage = Get-NCProgressPercent -Current $counter -Total $mailboxes.Count
             Write-Progress -Activity "Processing $($mailbox.PrimarySmtpAddress)" -Status "$counter of $($mailboxes.Count) - $Percentage%" -PercentComplete $Percentage
 
-            $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity
-            $sendAs = Get-RecipientPermission -Identity $exoMailbox.PrimarySmtpAddress -AccessRights SendAs | Where-Object { $_.Trustee.ToString() -ne 'NT AUTHORITY\SELF' -and $_.Trustee.ToString() -notlike 'S-1-5*' } | ForEach-Object { $_.Trustee.ToString() }
-            $fullAccess = Get-MailboxPermission -Identity $exoMailbox.PrimarySmtpAddress | Where-Object { $_.AccessRights -eq 'FullAccess' -and -not $_.IsInherited } | ForEach-Object { $_.User.ToString() }
+            try {
+                $exoMailbox = Get-EXOMailbox -Identity $mailbox.Identity -ErrorAction Stop
+                $sendAs = Get-RecipientPermission -Identity $exoMailbox.PrimarySmtpAddress -AccessRights SendAs -ErrorAction Stop | Where-Object { $_.Trustee.ToString() -ne 'NT AUTHORITY\SELF' -and $_.Trustee.ToString() -notlike 'S-1-5*' } | ForEach-Object { $_.Trustee.ToString() }
+                $fullAccess = Get-MailboxPermission -Identity $exoMailbox.PrimarySmtpAddress -ErrorAction Stop | Where-Object { $_.AccessRights -eq 'FullAccess' -and -not $_.IsInherited } | ForEach-Object { $_.User.ToString() }
 
-            $permissions.Add([pscustomobject]@{
+                $row = [pscustomobject]@{
                     Mailbox           = $exoMailbox.DisplayName
                     'Mailbox Address' = $exoMailbox.PrimarySmtpAddress
                     'Recipient Type'  = $exoMailbox.RecipientTypeDetails
                     FullAccess        = ($fullAccess -join ', ')
                     SendAs            = ($sendAs -join ', ')
                     SendOnBehalfTo    = $exoMailbox.GrantSendOnBehalfTo -join ', '
-                }) | Out-Null
+                }
+            }
+            catch {
+                Write-NCMessage "Failed to process mailbox '$($mailbox.PrimarySmtpAddress)': $($_.Exception.Message)" -Level ERROR
+                $consecutiveErrors++
+                if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                    $aborted = $true
+                    break
+                }
+                continue
+            }
+
+            if ($Resume -and $existingPermissionKeys.Contains((& $buildPermissionKey $row))) {
+                continue
+            }
+
+            $null = $existingPermissionKeys.Add((& $buildPermissionKey $row))
+            $permissions.Add($row) | Out-Null
+            $consecutiveErrors = 0
+
+            $processedSinceFlush++
+            if ($BatchSize -gt 0 -and $permissions.Count -gt 0 -and $processedSinceFlush -ge $BatchSize) {
+                & $writeBuffer $permissions
+                $processedSinceFlush = 0
+            }
         }
     }
 
     end {
         try {
-            $folder = Test-Folder $CsvFolder
-            $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-MboxPermissions-Report.csv"
-            $permissions | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-            Write-NCMessage "Mailbox permissions exported to $csvPath" -Level SUCCESS
+            if ($permissions.Count -eq 0) {
+                if ($Resume -and (Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new mailbox permissions found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No mailbox permissions were collected." -Level WARNING
+                }
+                return
+            }
+
+            & $writeBuffer $permissions
+            if ($aborted) {
+                Write-NCMessage "Mailbox permissions export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+            }
+            else {
+                Write-NCMessage "Mailbox permissions exported to $csvPathResolved" -Level SUCCESS
+            }
         }
         finally {
             Write-Progress -Activity "Processing mailbox permissions" -Completed
@@ -343,6 +476,14 @@ function Get-MboxAlias {
         Include recipients that have no secondary aliases in CSV exports.
     .PARAMETER IncludeMoera
         Include MOERA addresses in CSV exports.
+    .PARAMETER BatchSize
+        Number of processed recipients before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive recipient-level failures.
     .EXAMPLE
         Get-MboxAlias -SourceMailbox user@contoso.com
     .EXAMPLE
@@ -373,6 +514,24 @@ function Get-MboxAlias {
         [Parameter(ParameterSetName = 'All')]
         [Parameter(ParameterSetName = 'Domain')]
         [switch]$IncludeMoera,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [switch]$Resume,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [string]$CsvPath,
+        [Parameter(ParameterSetName = 'Single')]
+        [Parameter(ParameterSetName = 'All')]
+        [Parameter(ParameterSetName = 'Domain')]
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5,
         [Parameter(Mandatory, ParameterSetName = 'All')]
         [switch]$All,
         [Parameter(Mandatory, ParameterSetName = 'Domain')]
@@ -383,6 +542,9 @@ function Get-MboxAlias {
         Set-ProgressAndInfoPreferences
         $aliasRows = [System.Collections.Generic.List[object]]::new()
         $resolvedCsvFolder = $null
+        $processedSinceFlush = 0
+        $consecutiveErrors = 0
+        $aborted = $false
     }
 
     process {
@@ -398,6 +560,7 @@ function Get-MboxAlias {
             }
             catch {
                 Write-NCMessage "Recipient '$SourceMailbox' not available or not found." -Level ERROR
+                $consecutiveErrors++
                 return
             }
 
@@ -448,6 +611,68 @@ function Get-MboxAlias {
         $totalWorkUnits = [Math]::Max($recipientCount + $addressCount, 1)
         $completedWorkUnits = 0
         $recipientIndex = 0
+        $normalizeText = {
+            param($value)
+            return Get-NormalizedText -Value $value
+        }
+        $buildAliasKey = {
+            param($row)
+
+            $primary = & $normalizeText $row.PrimarySmtpAddress
+            $alias = & $normalizeText $row.Alias
+            $isPrimary = if ($null -ne $row.IsPrimary) { [string]$row.IsPrimary } else { $null }
+            $isMoera = if ($null -ne $row.IsMoera) { [string]$row.IsMoera } else { $null }
+            return "{0}|{1}|{2}|{3}" -f $primary, $alias, $isPrimary, $isMoera
+        }
+        $existingAliasKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        $csvPathResolved = $null
+
+        if ($willExport) {
+            $folderForExport = if ($resolvedCsvFolder) { $resolvedCsvFolder } else { Test-Folder $CsvFolder }
+            $defaultCsvPath = New-File "$folderForExport\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-Alias-Report.csv"
+            $csvPathResolved = $defaultCsvPath
+
+            if ($Resume) {
+                $resumePath = $null
+                if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                    $resumePath = $CsvPath
+                }
+                else {
+                    $existingCsv = Get-ChildItem -LiteralPath $folderForExport -File -Filter "*_M365-Alias-Report.csv" |
+                        Sort-Object LastWriteTime -Descending |
+                        Select-Object -First 1
+                    if ($existingCsv) {
+                        $resumePath = $existingCsv.FullName
+                    }
+                }
+
+                if ($resumePath) {
+                    $csvPathResolved = $resumePath
+                    if (Test-Path -LiteralPath $csvPathResolved) {
+                        try {
+                        foreach ($row in (Import-CSV -LiteralPath $csvPathResolved -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                $null = $existingAliasKeys.Add((& $buildAliasKey $row))
+                            }
+                            Write-NCMessage ("Resuming alias export from {0}; {1} row(s) already recorded." -f $csvPathResolved, $existingAliasKeys.Count) -Level INFO
+                        }
+                        catch {
+                            Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPathResolved, $_.Exception.Message) -Level WARNING
+                            $existingAliasKeys.Clear()
+                            $csvPathResolved = $defaultCsvPath
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPathResolved) -Level INFO
+                    }
+                }
+                else {
+                    Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPathResolved) -Level INFO
+                }
+            }
+
+            Write-NCMessage ("Alias export will flush every {0} recipient(s). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+            Write-NCMessage "Saving report to $csvPathResolved" -Level DEBUG
+        }
         $updateAliasProgress = {
             param(
                 [string]$Status,
@@ -475,6 +700,7 @@ function Get-MboxAlias {
                         $rows.Add([pscustomobject]@{
                                 DisplayName        = $recipient.DisplayName
                                 Name               = $recipient.Name
+                                UserPrincipalName  = $recipient.PrimarySmtpAddress
                                 PrimarySmtpAddress = $recipient.PrimarySmtpAddress
                                 Alias              = $address.Replace('SMTP:', '')
                                 IsPrimary          = $true
@@ -494,6 +720,7 @@ function Get-MboxAlias {
                         $rows.Add([pscustomobject]@{
                                 DisplayName        = $recipient.DisplayName
                                 Name               = $recipient.Name
+                                UserPrincipalName  = $recipient.PrimarySmtpAddress
                                 PrimarySmtpAddress = $recipient.PrimarySmtpAddress
                                 Alias              = $address.Replace('smtp:', '')
                                 IsPrimary          = $false
@@ -517,9 +744,9 @@ function Get-MboxAlias {
 
             if ($willExport) {
                 $exportRows = $rows
-                if (-not $IncludeMoera) {
-                    $exportRows = @($exportRows | Where-Object { -not $_.IsMoera })
-                }
+                    if (-not $IncludeMoera) {
+                        $exportRows = @($exportRows | Where-Object { -not $_.IsMoera })
+                    }
 
                 if ($exportRows.Count -eq 0) {
                     continue
@@ -529,40 +756,71 @@ function Get-MboxAlias {
                     continue
                 }
 
-                $aliasRows.AddRange($exportRows)
+                foreach ($row in $exportRows) {
+                    $rowKey = & $buildAliasKey $row
+                    if ($Resume -and $existingAliasKeys.Contains($rowKey)) {
+                        continue
+                    }
+
+                    $aliasRows.Add($row) | Out-Null
+                }
+
+                $processedSinceFlush++
+                if ($aliasRows.Count -gt 0 -and $processedSinceFlush -ge $BatchSize) {
+                    $aliasRows |
+                        Select-Object DisplayName, Name, UserPrincipalName, PrimarySmtpAddress, Alias, IsPrimary, IsMoera |
+                        Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                    $aliasRows.Clear()
+                    $processedSinceFlush = 0
+                }
             }
             else {
                 $aliasRows.AddRange($rows)
+            }
+
+            if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                $aborted = $true
+                break
             }
         }
 
         if ($aliasRows.Count -eq 0) {
             if ($willExport -and -not $IncludePrimaryOnly) {
-                Write-NCMessage "No secondary aliases found. Use -IncludePrimaryOnly to include recipients that only have a primary SMTP address." -Level WARNING
+                if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                    Write-NCMessage "No new aliases found. Existing CSV at $csvPathResolved already contains the requested rows." -Level INFO
+                }
+                else {
+                    Write-NCMessage "No secondary aliases found. Use -IncludePrimaryOnly to include recipients that only have a primary SMTP address." -Level WARNING
+                }
             }
             return
         }
 
-        $sortedAliases = $aliasRows | Sort-Object -Property PrimarySmtpAddress, @{ Expression = 'IsPrimary'; Descending = $true }, Alias
-
         if ($willExport) {
             & $updateAliasProgress -Status "Writing CSV export ..." -Advance
-            $exportAliases = $sortedAliases
+            $exportAliases = $aliasRows | Sort-Object -Property PrimarySmtpAddress, @{ Expression = 'IsPrimary'; Descending = $true }, Alias
 
             if ($exportAliases.Count -eq 0) {
                 Write-NCMessage "No exportable aliases found. Use -IncludeMoera to include MOERA addresses or -IncludePrimaryOnly to include recipients with only a primary SMTP address." -Level WARNING
                 return
             }
 
-            $folder = if ($resolvedCsvFolder) { $resolvedCsvFolder } else { Test-Folder $CsvFolder }
-            $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-Alias-Report.csv"
-            $exportAliases |
-                Select-Object DisplayName, Name, PrimarySmtpAddress, Alias, IsPrimary |
-                Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-            Write-NCMessage "Alias report exported to $csvPath" -Level SUCCESS
+            $finalExport = $exportAliases | Select-Object DisplayName, Name, UserPrincipalName, PrimarySmtpAddress, Alias, IsPrimary, IsMoera
+            if ((Test-Path -LiteralPath $csvPathResolved) -and ((Get-Item -LiteralPath $csvPathResolved).Length -gt 0)) {
+                $finalExport | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+            }
+            else {
+                $finalExport | Export-Csv -LiteralPath $csvPathResolved -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+            }
+            if ($aborted) {
+                Write-NCMessage "Alias report export stopped early. Partial data kept at $csvPathResolved." -Level ERROR
+            }
+            else {
+                Write-NCMessage "Alias report exported to $csvPathResolved" -Level SUCCESS
+            }
         }
         else {
-            $sortedAliases
+            $aliasRows | Sort-Object -Property PrimarySmtpAddress, @{ Expression = 'IsPrimary'; Descending = $true }, Alias
         }
     }
 
@@ -1267,7 +1525,7 @@ function Set-MboxLanguage {
             }
 
             try {
-                $mailboxes = (Import-Csv -LiteralPath $Csv) | Where-Object { $_.EmailAddress }
+                $mailboxes = (Import-Csv -LiteralPath $Csv -Delimiter $NCVars.CSV_DefaultLimiter) | Where-Object { $_.EmailAddress }
             }
             catch {
                 Write-NCMessage "Unable to read CSV file '$Csv'. $($_.Exception.Message)" -Level ERROR

--- a/Public/NC.Quarantine.ps1
+++ b/Public/NC.Quarantine.ps1
@@ -521,7 +521,7 @@ function Get-QuarantineToRelease {
         $counter = 0
         foreach ($item in $selection) {
             $counter++
-            $Percentage = [Math]::Round(($counter / [Math]::Max($selection.Count, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $counter -Total $selection.Count
             Write-Progress -Activity "Processing $($item.Subject)" -Status "$counter of $($selection.Count) - $Percentage%" -PercentComplete $Percentage
 
             if ($ReleaseSelected.IsPresent) {
@@ -734,7 +734,7 @@ function Unlock-QuarantineMessageId {
 
             $processed++
             if ($targetCount -gt 1) {
-                $Percentage = [Math]::Round(($processed / [Math]::Max($targetCount, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $targetCount
                 $statusMessage = "$processed of $targetCount ($($msg.Identity))"
                 Write-Progress -Activity "Releasing quarantined messages" -Status $statusMessage -PercentComplete $Percentage
             }
@@ -775,3 +775,5 @@ function Unlock-QuarantineMessageId {
 }
 
 Set-Alias -Name qrel -Value Unlock-QuarantineMessageId -Description "Releases quarantined messages by MessageId (function)"
+
+

--- a/Public/NC.Security.ps1
+++ b/Public/NC.Security.ps1
@@ -59,7 +59,7 @@ function Disable-UserDevices {
 
             foreach ($upn in $queue) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
                 Write-Progress -Activity "Resolving user $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -186,7 +186,7 @@ function Disable-UserSignIn {
 
             foreach ($upn in $queue) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
                 Write-Progress -Activity "Processing $upn" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 try {
@@ -348,7 +348,7 @@ function Revoke-UserSessions {
 
             foreach ($user in $queue) {
                 $counter++
-                $Percentage = [Math]::Round(($counter / [Math]::Max($queue.Count, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $counter -Total $queue.Count
                 Write-Progress -Activity "Revoking sessions" -Status "$counter of $($queue.Count) - $Percentage%" -PercentComplete $Percentage
 
                 if ($exclusions.Contains($user.UserPrincipalName)) {
@@ -387,3 +387,5 @@ function Revoke-UserSessions {
         }
     }
 }
+
+

--- a/Public/NC.Security.ps1
+++ b/Public/NC.Security.ps1
@@ -239,6 +239,479 @@ function Disable-UserSignIn {
     }
 }
 
+function Get-ContentFilterPolicy {
+    <#
+    .SYNOPSIS
+        Reads hosted content filter policy configuration.
+    .DESCRIPTION
+        Connects to Exchange Online and returns one or more hosted content filter policies. If no
+        policy name is provided, the function lists all available policies. The output includes the
+        current allow/block lists so you can inspect how each policy is configured before editing it.
+    .PARAMETER Identity
+        Hosted content filter policy name. If omitted, all policies are returned.
+    .PARAMETER Detailed
+        Include the resolved allow/block lists in the output.
+    .EXAMPLE
+        Get-ContentFilterPolicy
+    .EXAMPLE
+        Get-ContentFilterPolicy -Identity Contoso
+    .EXAMPLE
+        Get-ContentFilterPolicy -Detailed
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('SpamFilter', 'PolicyName')]
+        [string[]]$Identity,
+        [switch]$Detailed
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+        $targets = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($entry in $Identity) {
+            if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                $targets.Add($entry.Trim()) | Out-Null
+            }
+        }
+    }
+
+    end {
+        try {
+            if (-not (Test-EOLConnection)) {
+                Add-EmptyLine
+                Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
+                return
+            }
+
+            $policyObjects = [System.Collections.Generic.List[object]]::new()
+
+            if ($targets.Count -eq 0) {
+                try {
+                    $policyObjects.AddRange(@(Get-HostedContentFilterPolicy -ErrorAction Stop))
+                }
+                catch {
+                    Write-NCMessage "Unable to retrieve hosted content filter policies. $($_.Exception.Message)" -Level ERROR
+                    return
+                }
+
+                if ($policyObjects.Count -eq 0) {
+                    Write-NCMessage "No hosted content filter policies were found." -Level WARNING
+                    return
+                }
+            }
+            else {
+                $dedup = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+                foreach ($policyName in $targets) {
+                    if (-not $dedup.Add($policyName)) {
+                        continue
+                    }
+
+                    try {
+                        $policyObjects.Add((Get-HostedContentFilterPolicy -Identity $policyName -ErrorAction Stop)) | Out-Null
+                    }
+                    catch {
+                        Write-NCMessage "Unable to read hosted content filter policy '$policyName'. $($_.Exception.Message)" -Level ERROR
+                    }
+                }
+
+                if ($policyObjects.Count -eq 0) {
+                    Write-NCMessage "No hosted content filter policies matched the requested identity or identities." -Level WARNING
+                    return
+                }
+            }
+            $policyObjects |
+                Sort-Object Name |
+                ForEach-Object {
+                    $blockedSenders = @(Get-NCContentFilterPolicyValues -PolicyObject $_ -PropertyName 'BlockedSenders' -PreferredValueProperty 'Sender')
+                    $blockedSenderDomains = @(Get-NCContentFilterPolicyValues -PolicyObject $_ -PropertyName 'BlockedSenderDomains' -PreferredValueProperty 'Domain')
+                    $allowedSenders = @(Get-NCContentFilterPolicyValues -PolicyObject $_ -PropertyName 'AllowedSenders' -PreferredValueProperty 'Sender')
+                    $allowedSenderDomains = @(Get-NCContentFilterPolicyValues -PolicyObject $_ -PropertyName 'AllowedSenderDomains' -PreferredValueProperty 'Domain')
+
+                    $summary = [ordered]@{
+                        Identity            = $_.Identity
+                        Name                = $_.Name
+                        Enabled             = $_.Enabled
+                        Priority            = $_.Priority
+                        BlockedSenderCount  = $blockedSenders.Count
+                        BlockedDomainCount  = $blockedSenderDomains.Count
+                        AllowedSenderCount  = $allowedSenders.Count
+                        AllowedDomainCount  = $allowedSenderDomains.Count
+                    }
+
+                    if ($Detailed.IsPresent) {
+                        $summary.BlockedSenders = $blockedSenders
+                        $summary.BlockedSenderDomains = $blockedSenderDomains
+                        $summary.AllowedSenders = $allowedSenders
+                        $summary.AllowedSenderDomains = $allowedSenderDomains
+                    }
+
+                    [pscustomobject]$summary
+                }
+        }
+        finally {
+            Restore-ProgressAndInfoPreferences
+        }
+    }
+}
+
+function Edit-ContentFilterPolicy {
+    <#
+    .SYNOPSIS
+        Updates a hosted content filter policy allow/block list.
+    .DESCRIPTION
+        Connects to Exchange Online, loads a hosted content filter policy, and adds or removes
+        blocked senders, blocked domains, allowed senders, or allowed domains. When allowed senders
+        are updated, the helper also keeps the configured allowed-senders group in sync and creates
+        missing mail contacts. When allowed domains are updated, the helper also synchronizes the
+        sender-domain exceptions on the configured transport rules.
+    .PARAMETER Identity
+        Hosted content filter policy name. Accepts the legacy SpamFilter alias.
+    .PARAMETER BlockedSender
+        Sender address to add or remove from the blocked senders list.
+    .PARAMETER BlockedDomain
+        Domain to add or remove from the blocked sender domains list.
+    .PARAMETER AllowedSender
+        Sender address to add or remove from the allowed senders list.
+    .PARAMETER AllowedDomain
+        Domain to add or remove from the allowed sender domains list.
+    .PARAMETER AllowedSendersGroup
+        Distribution group used to keep the allowed senders group in sync.
+    .PARAMETER TransportRuleNames
+        Transport rules that should mirror allowed-domain exceptions.
+    .PARAMETER Remove
+        Remove the provided values instead of adding them.
+    .EXAMPLE
+        Edit-ContentFilterPolicy -Identity Contoso -BlockedSender user@contoso.com
+    .EXAMPLE
+        Edit-ContentFilterPolicy -Identity Contoso -AllowedDomain contoso.com -Remove
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
+        [Alias('SpamFilter', 'PolicyName')]
+        [string]$Identity,
+        [string[]]$BlockedSender,
+        [string[]]$BlockedDomain,
+        [string[]]$AllowedSender,
+        [string[]]$AllowedDomain,
+        [string]$AllowedSendersGroup,
+        [string[]]$TransportRuleNames,
+        [switch]$Remove
+    )
+
+    begin {
+        Set-ProgressAndInfoPreferences
+    }
+
+    process {
+        if (-not (Test-EOLConnection)) {
+            Add-EmptyLine
+            Write-NCMessage "Can't connect or use Microsoft Exchange Online Management module. Please check logs." -Level ERROR
+            return
+        }
+
+        $blockedSendersQueue = @(
+            foreach ($entry in @($BlockedSender)) {
+                if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                    $entry.Trim()
+                }
+            }
+        ) | Sort-Object -Unique
+
+        $blockedDomainsQueue = @(
+            foreach ($entry in @($BlockedDomain)) {
+                if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                    $entry.Trim()
+                }
+            }
+        ) | Sort-Object -Unique
+
+        $allowedSendersQueue = @(
+            foreach ($entry in @($AllowedSender)) {
+                if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                    $entry.Trim()
+                }
+            }
+        ) | Sort-Object -Unique
+
+        $allowedDomainsQueue = @(
+            foreach ($entry in @($AllowedDomain)) {
+                if (-not [string]::IsNullOrWhiteSpace($entry)) {
+                    $entry.Trim()
+                }
+            }
+        ) | Sort-Object -Unique
+
+        $modeLabel = if ($Remove.IsPresent) { 'Remove' } else { 'Add' }
+
+        if ($blockedSendersQueue.Count -eq 0 -and $blockedDomainsQueue.Count -eq 0 -and $allowedSendersQueue.Count -eq 0 -and $allowedDomainsQueue.Count -eq 0) {
+            Write-NCMessage "No changes requested. Returning the current policy state." -Level INFO
+        }
+
+        try {
+            $policy = Get-HostedContentFilterPolicy -Identity $Identity -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Unable to read hosted content filter policy '$Identity'. $($_.Exception.Message)" -Level ERROR
+            return
+        }
+
+        $transportRules = [System.Collections.Generic.List[object]]::new()
+        foreach ($ruleName in @($TransportRuleNames)) {
+            if ([string]::IsNullOrWhiteSpace($ruleName)) {
+                continue
+            }
+
+            try {
+                $rule = Get-TransportRule -Identity $ruleName -ErrorAction Stop
+                $transportRules.Add($rule) | Out-Null
+            }
+            catch {
+                Write-NCMessage "Transport rule '$ruleName' was not found or could not be read. $($_.Exception.Message)" -Level WARNING
+            }
+        }
+
+        $contactGroup = $null
+        if (-not [string]::IsNullOrWhiteSpace($AllowedSendersGroup)) {
+            try {
+                $contactGroup = Get-DistributionGroup -Identity $AllowedSendersGroup -ErrorAction Stop
+            }
+            catch {
+                Write-NCMessage "Allowed senders group '$AllowedSendersGroup' was not found or could not be read. $($_.Exception.Message)" -Level WARNING
+            }
+        }
+
+        if ($allowedSendersQueue.Count -gt 0 -and -not $contactGroup) {
+            Write-NCMessage "Allowed sender updates will skip group synchronization because -AllowedSendersGroup was not provided or could not be resolved." -Level INFO
+        }
+
+        if ($allowedDomainsQueue.Count -gt 0 -and $transportRules.Count -eq 0) {
+            Write-NCMessage "Allowed domain updates will skip transport-rule synchronization because -TransportRuleNames was not provided or no rules could be resolved." -Level INFO
+        }
+
+        $changes = [System.Collections.Generic.List[object]]::new()
+        $updateDomainList = {
+            param(
+                [object]$CurrentValues,
+                [string]$Entry,
+                [switch]$Remove
+            )
+
+            $set = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            foreach ($value in @($CurrentValues)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$value)) {
+                    [void]$set.Add(([string]$value).Trim())
+                }
+            }
+
+            if ($Remove) {
+                [void]$set.Remove($Entry)
+            }
+            else {
+                [void]$set.Add($Entry)
+            }
+
+            return @($set)
+        }
+
+        Write-NCMessage "Policy: $Identity" -Level INFO
+        Write-NCMessage ("Mode: {0}" -f $modeLabel) -Level INFO
+
+        foreach ($entry in $blockedSendersQueue) {
+            $actionText = if ($Remove.IsPresent) { "remove blocked sender '$entry'" } else { "add blocked sender '$entry'" }
+            if (-not $PSCmdlet.ShouldProcess($Identity, $actionText)) {
+                continue
+            }
+
+            try {
+                if ($Remove.IsPresent) {
+                    Set-HostedContentFilterPolicy -Identity $Identity -BlockedSenders @{ remove = $entry } -ErrorAction Stop | Out-Null
+                }
+                else {
+                    Set-HostedContentFilterPolicy -Identity $Identity -BlockedSenders @{ add = $entry } -ErrorAction Stop | Out-Null
+                }
+
+                $changes.Add([pscustomobject]@{
+                        Scope  = 'BlockedSenders'
+                        Value  = $entry
+                        Action = $(if ($Remove.IsPresent) { 'Removed' } else { 'Added' })
+                    }) | Out-Null
+            }
+            catch {
+                Write-NCMessage "Unable to update blocked sender '$entry' on '$Identity'. $($_.Exception.Message)" -Level ERROR
+            }
+        }
+
+        foreach ($entry in $blockedDomainsQueue) {
+            $actionText = if ($Remove.IsPresent) { "remove blocked domain '$entry'" } else { "add blocked domain '$entry'" }
+            if (-not $PSCmdlet.ShouldProcess($Identity, $actionText)) {
+                continue
+            }
+
+            try {
+                if ($Remove.IsPresent) {
+                    Set-HostedContentFilterPolicy -Identity $Identity -BlockedSenderDomains @{ remove = $entry } -ErrorAction Stop | Out-Null
+                }
+                else {
+                    Set-HostedContentFilterPolicy -Identity $Identity -BlockedSenderDomains @{ add = $entry } -ErrorAction Stop | Out-Null
+                }
+
+                $changes.Add([pscustomobject]@{
+                        Scope  = 'BlockedSenderDomains'
+                        Value  = $entry
+                        Action = $(if ($Remove.IsPresent) { 'Removed' } else { 'Added' })
+                    }) | Out-Null
+            }
+            catch {
+                Write-NCMessage "Unable to update blocked sender domain '$entry' on '$Identity'. $($_.Exception.Message)" -Level ERROR
+            }
+        }
+
+        foreach ($entry in $allowedSendersQueue) {
+            $actionText = if ($Remove.IsPresent) { "remove allowed sender '$entry'" } else { "add allowed sender '$entry'" }
+            if (-not $PSCmdlet.ShouldProcess($Identity, $actionText)) {
+                continue
+            }
+
+            try {
+                if (-not $Remove.IsPresent) {
+                    $contact = Get-MailContact -Identity $entry -ErrorAction SilentlyContinue
+                    if (-not $contact) {
+                        New-MailContact -DisplayName $entry -Name $entry -ExternalEmailAddress $entry -ErrorAction Stop | Out-Null
+                        Write-NCMessage "Created mail contact for '$entry'." -Level SUCCESS
+                    }
+
+                    Set-MailContact -Identity $entry -HiddenFromAddressListsEnabled $true -ErrorAction Stop | Out-Null
+
+                    if ($contactGroup) {
+                        try {
+                            Add-DistributionGroupMember -Identity $contactGroup.Identity -Member $entry -ErrorAction Stop | Out-Null
+                        }
+                        catch {
+                            Write-NCMessage "Unable to add '$entry' to allowed senders group '$AllowedSendersGroup'. $($_.Exception.Message)" -Level WARNING
+                        }
+                    }
+                }
+                else {
+                    if ($contactGroup) {
+                        try {
+                            Remove-DistributionGroupMember -Identity $contactGroup.Identity -Member $entry -Confirm:$false -ErrorAction Stop | Out-Null
+                        }
+                        catch {
+                            Write-NCMessage "Unable to remove '$entry' from allowed senders group '$AllowedSendersGroup'. $($_.Exception.Message)" -Level WARNING
+                        }
+                    }
+                }
+
+                if ($Remove.IsPresent) {
+                    Set-HostedContentFilterPolicy -Identity $Identity -AllowedSenders @{ remove = $entry } -ErrorAction Stop | Out-Null
+                }
+                else {
+                    Set-HostedContentFilterPolicy -Identity $Identity -AllowedSenders @{ add = $entry } -ErrorAction Stop | Out-Null
+                }
+
+                $changes.Add([pscustomobject]@{
+                        Scope  = 'AllowedSenders'
+                        Value  = $entry
+                        Action = $(if ($Remove.IsPresent) { 'Removed' } else { 'Added' })
+                    }) | Out-Null
+            }
+            catch {
+                Write-NCMessage "Unable to update allowed sender '$entry' on '$Identity'. $($_.Exception.Message)" -Level ERROR
+            }
+        }
+
+        foreach ($entry in $allowedDomainsQueue) {
+            $actionText = if ($Remove.IsPresent) { "remove allowed domain '$entry'" } else { "add allowed domain '$entry'" }
+            if (-not $PSCmdlet.ShouldProcess($Identity, $actionText)) {
+                continue
+            }
+
+            try {
+                if ($Remove.IsPresent) {
+                    Set-HostedContentFilterPolicy -Identity $Identity -AllowedSenderDomains @{ remove = $entry } -ErrorAction Stop | Out-Null
+                }
+                else {
+                    Set-HostedContentFilterPolicy -Identity $Identity -AllowedSenderDomains @{ add = $entry } -ErrorAction Stop | Out-Null
+                }
+
+                foreach ($rule in $transportRules) {
+                    $currentDomains = @($rule.ExceptIfSenderDomainIs)
+                    $updatedDomains = & $updateDomainList $currentDomains $entry -Remove:$Remove.IsPresent
+                    $ruleActionText = if ($Remove.IsPresent) {
+                        "remove sender-domain exception '$entry' from transport rule '$($rule.Name)'"
+                    }
+                    else {
+                        "add sender-domain exception '$entry' to transport rule '$($rule.Name)'"
+                    }
+
+                    if (-not $PSCmdlet.ShouldProcess($rule.Name, $ruleActionText)) {
+                        continue
+                    }
+
+                    try {
+                        if ($updatedDomains.Count -gt 0) {
+                            Set-TransportRule -Identity $rule.Identity -ExceptIfSenderDomainIs $updatedDomains -ErrorAction Stop | Out-Null
+                        }
+                        else {
+                            Set-TransportRule -Identity $rule.Identity -ExceptIfSenderDomainIs $null -ErrorAction Stop | Out-Null
+                        }
+                    }
+                    catch {
+                        Write-NCMessage "Unable to update transport rule '$($rule.Name)' for domain '$entry'. $($_.Exception.Message)" -Level WARNING
+                    }
+                }
+
+                $changes.Add([pscustomobject]@{
+                        Scope  = 'AllowedSenderDomains'
+                        Value  = $entry
+                        Action = $(if ($Remove.IsPresent) { 'Removed' } else { 'Added' })
+                    }) | Out-Null
+            }
+            catch {
+                Write-NCMessage "Unable to update allowed sender domain '$entry' on '$Identity'. $($_.Exception.Message)" -Level ERROR
+            }
+        }
+
+        try {
+            $updatedPolicy = Get-HostedContentFilterPolicy -Identity $Identity -ErrorAction Stop
+        }
+        catch {
+            Write-NCMessage "Policy '$Identity' was updated, but the refreshed policy could not be read back. $($_.Exception.Message)" -Level WARNING
+            $updatedPolicy = $policy
+        }
+
+        $summary = [pscustomobject]@{
+            Identity             = $updatedPolicy.Identity
+            DisplayName           = $updatedPolicy.Name
+            AllowedSenders        = @(Get-NCContentFilterPolicyValues -PolicyObject $updatedPolicy -PropertyName 'AllowedSenders' -PreferredValueProperty 'Sender')
+            AllowedSenderDomains  = @(Get-NCContentFilterPolicyValues -PolicyObject $updatedPolicy -PropertyName 'AllowedSenderDomains' -PreferredValueProperty 'Domain')
+            BlockedSenders        = @(Get-NCContentFilterPolicyValues -PolicyObject $updatedPolicy -PropertyName 'BlockedSenders' -PreferredValueProperty 'Sender')
+            BlockedSenderDomains  = @(Get-NCContentFilterPolicyValues -PolicyObject $updatedPolicy -PropertyName 'BlockedSenderDomains' -PreferredValueProperty 'Domain')
+            AllowedSendersGroup   = $AllowedSendersGroup
+            TransportRuleNames    = @($transportRules | Select-Object -ExpandProperty Name)
+            Changes               = @($changes)
+        }
+
+        if ($changes.Count -gt 0) {
+            Write-NCMessage ("Updated content filter policy '{0}' with {1} change(s)." -f $Identity, $changes.Count) -Level SUCCESS
+        }
+        else {
+            Write-NCMessage "No policy changes were applied." -Level INFO
+        }
+
+        return $summary
+    }
+
+    end {
+        Restore-ProgressAndInfoPreferences
+    }
+}
+
 function Revoke-UserSessions {
     <#
     .SYNOPSIS
@@ -387,5 +860,6 @@ function Revoke-UserSessions {
         }
     }
 }
+
 
 

--- a/Public/NC.Statistics.ps1
+++ b/Public/NC.Statistics.ps1
@@ -75,7 +75,7 @@ function Export-MboxStatistics {
 
         foreach ($mailbox in $mailboxes) {
             $processedCount++
-            $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+            $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalMailboxes
             Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
             $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
@@ -221,7 +221,7 @@ function Export-MboxDeletedItemSize {
 
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
-                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalMailboxes
                 Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
@@ -241,7 +241,6 @@ function Export-MboxDeletedItemSize {
                 $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DeletedItemSize.csv"
                 $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
                 Write-NCMessage "Deleted item size report exported to $csvPath." -Level SUCCESS
-                $csvPath
             }
             else {
                 $report
@@ -332,7 +331,7 @@ function Get-MboxStatistics {
 
             foreach ($mailbox in $mailboxes) {
                 $processedCount++
-                $Percentage = [Math]::Round(($processedCount / [Math]::Max($totalMailboxes, 1)) * 100, 2)
+                $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalMailboxes
                 Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
@@ -448,3 +447,5 @@ function Get-MboxStatistics {
         }
     }
 }
+
+

--- a/Public/NC.Statistics.ps1
+++ b/Public/NC.Statistics.ps1
@@ -19,6 +19,12 @@ function Export-MboxStatistics {
         Round quota values up to the nearest integer GB.
     .PARAMETER BatchSize
         Number of processed mailboxes before flushing partial CSV output (defaults to 25).
+    .PARAMETER Resume
+        Resume from the most recent existing mailbox statistics CSV in the target folder.
+    .PARAMETER CsvPath
+        Optional CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop the export after this many mailbox-level failures in a row.
     #>
     [CmdletBinding()]
     param(
@@ -26,9 +32,13 @@ function Export-MboxStatistics {
         [Alias('User', 'Identity')]
         [string]$UserPrincipalName,
         [string]$CsvFolder,
+        [string]$CsvPath,
         [switch]$Round,
         [ValidateRange(1, 500)]
-        [int]$BatchSize = 25
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     Set-ProgressAndInfoPreferences
@@ -63,32 +73,142 @@ function Export-MboxStatistics {
         $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
         $statsBuffer = New-Object System.Collections.Generic.List[object]
         $processedCount = 0
-        $totalMailboxes = $mailboxes.Count
         $writeToCsv = $exportAll
         $csvPath = $null
         $csvInitialized = $false
+        $failedInARow = 0
+        $aborted = $false
+        $normalizeIdentity = {
+            param([object]$Value)
+
+            if ($null -eq $Value) {
+                return $null
+            }
+
+            $text = [string]$Value
+            if ([string]::IsNullOrWhiteSpace($text)) {
+                return $null
+            }
+
+            return $text.Trim().ToLowerInvariant()
+        }
+        $processedIdentities = [System.Collections.Generic.HashSet[string]]::new()
+        $pendingMailboxes = [System.Collections.Generic.List[object]]::new()
 
         if ($writeToCsv) {
-            $csvPath = New-File("$($folder)\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-MailboxStatistics.csv")
+            $defaultCsvPath = New-File("$($folder)\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-MailboxStatistics.csv")
+            if ($Resume) {
+                $resumePath = $null
+                if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                    $resumePath = $CsvPath
+                }
+                else {
+                    $existingCsv = Get-ChildItem -LiteralPath $folder -File -Filter "*_M365-MailboxStatistics.csv" |
+                        Sort-Object LastWriteTime -Descending |
+                        Select-Object -First 1
+
+                    if ($existingCsv) {
+                        $resumePath = $existingCsv.FullName
+                    }
+                }
+
+                if ($resumePath) {
+                    $csvPath = $resumePath
+                    if (Test-Path -LiteralPath $csvPath) {
+                        $csvInitialized = ((Get-Item -LiteralPath $csvPath).Length -gt 0)
+
+                        try {
+                            foreach ($row in (Import-CSV -LiteralPath $csvPath -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                $identity = & $normalizeIdentity $row.UserPrincipalName
+                                if (-not $identity) {
+                                    $identity = & $normalizeIdentity $row.PrimarySmtpAddress
+                                }
+                                if (-not $identity) {
+                                    $identity = & $normalizeIdentity $row.UserName
+                                }
+
+                                if ($identity) {
+                                    $null = $processedIdentities.Add($identity)
+                                }
+                            }
+                        }
+                        catch {
+                            Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csvPath, $_.Exception.Message) -Level WARNING
+                            $processedIdentities.Clear()
+                            $csvPath = $defaultCsvPath
+                            $csvInitialized = $false
+                        }
+
+                        if ($csvPath -ne $defaultCsvPath) {
+                            Write-NCMessage ("Resuming mailbox statistics from {0}; {1} mailbox(es) already recorded." -f $csvPath, $processedIdentities.Count) -Level INFO
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csvPath) -Level INFO
+                    }
+                }
+                else {
+                    $csvPath = $defaultCsvPath
+                    Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csvPath) -Level INFO
+                }
+            }
+            else {
+                $csvPath = $defaultCsvPath
+            }
+
+            Write-NCMessage ("Mailbox statistics export will flush every {0} mailbox(es). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
             Write-NCMessage "Saving report to $csvPath" -Level DEBUG
+
+            foreach ($mailbox in $mailboxes) {
+                $identity = & $normalizeIdentity $mailbox.UserPrincipalName
+                if (-not $identity) {
+                    $identity = & $normalizeIdentity $mailbox.PrimarySmtpAddress
+                }
+
+                if ($Resume -and $identity -and $processedIdentities.Contains($identity)) {
+                    continue
+                }
+
+                $null = $pendingMailboxes.Add($mailbox)
+            }
+        }
+        else {
+            foreach ($mailbox in $mailboxes) {
+                $null = $pendingMailboxes.Add($mailbox)
+            }
         }
 
-        foreach ($mailbox in $mailboxes) {
+        $totalMailboxes = $pendingMailboxes.Count
+
+        if ($writeToCsv -and $Resume -and $csvPath -and $processedIdentities.Count -gt 0 -and $totalMailboxes -eq 0) {
+            Write-NCMessage "All matching mailboxes are already present in the CSV. Nothing to do." -Level WARNING
+            return
+        }
+
+        foreach ($mailbox in $pendingMailboxes) {
             $processedCount++
             $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalMailboxes
             Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
+            $mailboxHadError = $false
             $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
+            if ($null -eq $stats) {
+                $mailboxHadError = $true
+            }
             $mailboxSizeGb = if ($stats) { Convert-MbxSizeToGB -SizeObject $stats.TotalItemSize } else { "Error" }
 
             $hasArchive = ($mailbox.ArchiveStatus -eq 'Active') -or ($mailbox.ArchiveGuid -and $mailbox.ArchiveGuid -ne [guid]::Empty)
             $archiveSize = $null
             if ($hasArchive) {
                 $archiveStats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName -Archive
+                if ($null -eq $archiveStats) {
+                    $mailboxHadError = $true
+                }
                 $archiveSize = if ($archiveStats) { Convert-MbxSizeToGB -SizeObject $archiveStats.TotalItemSize } else { "Error" }
             }
 
             $record = [pscustomobject][ordered]@{
+                UserPrincipalName           = $mailbox.UserPrincipalName
                 UserName                     = $mailbox.DisplayName
                 ServerName                   = $mailbox.ServerName
                 Database                     = $mailbox.Database
@@ -114,6 +234,30 @@ function Export-MboxStatistics {
 
             $statsBuffer.Add($record) | Out-Null
 
+            if ($mailboxHadError) {
+                $failedInARow++
+            }
+            else {
+                $failedInARow = 0
+            }
+
+            if ($MaxConsecutiveErrors -gt 0 -and $failedInARow -ge $MaxConsecutiveErrors) {
+                if ($writeToCsv -and $statsBuffer.Count -gt 0) {
+                    if ($csvInitialized) {
+                        $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter) -Append
+                    }
+                    else {
+                        $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
+                        $csvInitialized = $true
+                    }
+                    $statsBuffer.Clear()
+                }
+
+                Write-NCMessage ("Stopping export after {0} consecutive mailbox error(s). Partial report kept at {1}." -f $failedInARow, $csvPath) -Level ERROR
+                $aborted = $true
+                break
+            }
+
             if ($writeToCsv -and (($processedCount % $BatchSize) -eq 0)) {
                 if ($csvInitialized) {
                     $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter) -Append
@@ -127,7 +271,7 @@ function Export-MboxStatistics {
             }
         }
 
-        if ($writeToCsv) {
+        if ($writeToCsv -and -not $aborted) {
             if ($statsBuffer.Count -gt 0) {
                 if ($csvInitialized) {
                     $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter) -Append
@@ -138,6 +282,16 @@ function Export-MboxStatistics {
             }
 
             Write-NCMessage "Mailbox statistics exported to $csvPath." -Level SUCCESS
+        }
+        elseif ($aborted) {
+            if ($statsBuffer.Count -gt 0) {
+                if ($csvInitialized) {
+                    $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter) -Append
+                }
+                else {
+                    $statsBuffer | Export-CSV -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $($NCVars.CSV_DefaultLimiter)
+                }
+            }
         }
         else {
             $statsBuffer
@@ -163,6 +317,14 @@ function Export-MboxDeletedItemSize {
         Destination folder for the CSV file when exporting the report.
     .PARAMETER Csv
         When present, export the report to CSV. Defaults to on.
+    .PARAMETER BatchSize
+        Number of processed mailboxes before flushing partial CSV output.
+    .PARAMETER Resume
+        Resume from the latest matching CSV in the target folder or from -CsvPath.
+    .PARAMETER CsvPath
+        Explicit CSV file to resume. When omitted, the most recent matching CSV in the target folder is used.
+    .PARAMETER MaxConsecutiveErrors
+        Stop after this many consecutive mailbox-level failures.
     #>
     [CmdletBinding()]
     param(
@@ -170,13 +332,22 @@ function Export-MboxDeletedItemSize {
         [Alias('User', 'Identity', 'Mailbox', 'SourceMailbox')]
         [string[]]$UserPrincipalName,
         [string]$CsvFolder,
-        [bool]$Csv = $true
+        [bool]$Csv = $true,
+        [ValidateRange(1, 500)]
+        [int]$BatchSize = 25,
+        [switch]$Resume,
+        [string]$CsvPath,
+        [ValidateRange(1, 100)]
+        [int]$MaxConsecutiveErrors = 5
     )
 
     begin {
         Set-ProgressAndInfoPreferences
         $requestedMailboxes = [System.Collections.Generic.List[string]]::new()
         $report = [System.Collections.Generic.List[object]]::new()
+        $processedSinceFlush = 0
+        $consecutiveErrors = 0
+        $aborted = $false
     }
 
     process {
@@ -216,6 +387,54 @@ function Export-MboxDeletedItemSize {
                 return
             }
 
+            $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
+            $defaultCsvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DeletedItemSize.csv"
+            $csv = $defaultCsvPath
+            $processedMailboxes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+            if ($Resume) {
+                $resumePath = $null
+                if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+                    $resumePath = $CsvPath
+                }
+                else {
+                    $existingCsv = Get-ChildItem -LiteralPath $folder -File -Filter "*_M365-DeletedItemSize.csv" |
+                        Sort-Object LastWriteTime -Descending |
+                        Select-Object -First 1
+                    if ($existingCsv) {
+                        $resumePath = $existingCsv.FullName
+                    }
+                }
+
+                if ($resumePath) {
+                    $csv = $resumePath
+                    if (Test-Path -LiteralPath $csv) {
+                        try {
+                            foreach ($row in (Import-CSV -LiteralPath $csv -Delimiter $NCVars.CSV_DefaultLimiter -ErrorAction Stop)) {
+                                if ($row.UserPrincipalName) {
+                                    $null = $processedMailboxes.Add(([string]$row.UserPrincipalName).Trim())
+                                }
+                            }
+                            Write-NCMessage ("Resuming deleted item export from {0}; {1} mailbox(es) already recorded." -f $csv, $processedMailboxes.Count) -Level INFO
+                        }
+                        catch {
+                            Write-NCMessage ("Unable to read existing CSV '{0}' for resume. {1}" -f $csv, $_.Exception.Message) -Level WARNING
+                            $processedMailboxes.Clear()
+                            $csv = $defaultCsvPath
+                        }
+                    }
+                    else {
+                        Write-NCMessage ("Resume requested for '{0}', but the file does not exist. Starting a new report at that path." -f $csv) -Level INFO
+                    }
+                }
+                else {
+                    Write-NCMessage ("Resume requested, but no existing CSV was found. Starting a new report at {0}." -f $csv) -Level INFO
+                }
+            }
+
+            Write-NCMessage ("Deleted item export will flush every {0} mailbox(es). Resume: {1}. Stop after {2} consecutive error(s)." -f $BatchSize, $Resume.IsPresent, $MaxConsecutiveErrors) -Level INFO
+            Write-NCMessage "Saving report to $csv" -Level DEBUG
+
             $totalMailboxes = $mailboxes.Count
             $processedCount = 0
 
@@ -224,23 +443,72 @@ function Export-MboxDeletedItemSize {
                 $Percentage = Get-NCProgressPercent -Current $processedCount -Total $totalMailboxes
                 Write-Progress -Activity "Processing $($mailbox.DisplayName)" -Status "$processedCount of $totalMailboxes - $Percentage%" -PercentComplete $Percentage
 
+                if ($Resume -and $mailbox.UserPrincipalName -and $processedMailboxes.Contains($mailbox.UserPrincipalName)) {
+                    Write-Verbose "Skipping $($mailbox.UserPrincipalName), already processed."
+                    continue
+                }
+
                 $stats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName
                 if (-not $stats) {
+                    $consecutiveErrors++
+                    if ($MaxConsecutiveErrors -gt 0 -and $consecutiveErrors -ge $MaxConsecutiveErrors) {
+                        if ($report.Count -gt 0) {
+                            if ((Test-Path -LiteralPath $csv) -and ((Get-Item -LiteralPath $csv).Length -gt 0)) {
+                                $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                            }
+                            else {
+                                $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                            }
+                            $report.Clear()
+                        }
+
+                        Write-NCMessage ("Stopping export after {0} consecutive mailbox error(s). Partial report kept at {1}." -f $consecutiveErrors, $csv) -Level ERROR
+                        $aborted = $true
+                        break
+                    }
                     continue
                 }
 
                 $report.Add([pscustomobject][ordered]@{
+                        UserPrincipalName      = $mailbox.UserPrincipalName
                         DisplayName            = $mailbox.DisplayName
                         PrimarySmtpAddress     = $mailbox.PrimarySmtpAddress
                         TotalDeletedItemSizeGB = Convert-MbxSizeToGB -SizeObject $stats.TotalDeletedItemSize
                     }) | Out-Null
+
+                $null = $processedMailboxes.Add($mailbox.UserPrincipalName)
+                $consecutiveErrors = 0
+                $processedSinceFlush++
+
+                if ($processedSinceFlush -ge $BatchSize -and $report.Count -gt 0) {
+                    if ((Test-Path -LiteralPath $csv) -and ((Get-Item -LiteralPath $csv).Length -gt 0)) {
+                        $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                    }
+                    else {
+                        $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                    }
+                    Write-Verbose "Processed $processedCount / $totalMailboxes mailboxes, flushed batch to CSV."
+                    $report.Clear()
+                    $processedSinceFlush = 0
+                }
+            }
+
+            if ($Csv -and $report.Count -gt 0) {
+                if ((Test-Path -LiteralPath $csv) -and ((Get-Item -LiteralPath $csv).Length -gt 0)) {
+                    $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter -Append
+                }
+                else {
+                    $report | Export-Csv -LiteralPath $csv -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
+                }
             }
 
             if ($Csv) {
-                $folder = if ($CsvFolder) { Test-Folder $CsvFolder } else { Test-Folder $null }
-                $csvPath = New-File "$folder\$((Get-Date -Format $NCVars.DateTimeString_CSV))_M365-DeletedItemSize.csv"
-                $report | Export-Csv -LiteralPath $csvPath -NoTypeInformation -Encoding $NCVars.CSV_Encoding -Delimiter $NCVars.CSV_DefaultLimiter
-                Write-NCMessage "Deleted item size report exported to $csvPath." -Level SUCCESS
+                if ($aborted) {
+                    Write-NCMessage "Deleted item size report export stopped early. Partial data kept at $csv." -Level ERROR
+                }
+                else {
+                    Write-NCMessage "Deleted item size report exported to $csv." -Level SUCCESS
+                }
             }
             else {
                 $report
@@ -264,7 +532,7 @@ function Get-MboxStatistics {
     .PARAMETER UserPrincipalName
         Optional single mailbox identity. When omitted, returns all mailboxes.
     .PARAMETER IncludeArchive
-        When present, includes archive size and archive usage percentage (if available).
+        When present, includes archive size, archive quota, and archive usage percentage (if available).
     .PARAMETER IncludeMessageActivity
         When present, includes latest message trace info and oldest mailbox item metadata
         (LastReceived, LastSent, OldestItemReceivedDate, OldestItemFolderPath).
@@ -371,12 +639,13 @@ function Get-MboxStatistics {
 
                 $archiveSize = $null
                 $archivePercentUsed = $null
+                $archiveQuota = $null
                 $hasArchive = ($mailbox.ArchiveStatus -eq 'Active') -or ($mailbox.ArchiveGuid -and $mailbox.ArchiveGuid -ne [guid]::Empty)
                 if ($IncludeArchive -and $hasArchive) {
+                    $archiveQuota = Resolve-MbxQuotaValue -RawValue $mailbox.ArchiveQuota -Round:$Round
                     $archiveStats = Get-MailboxStatisticsSafe -Identity $mailbox.UserPrincipalName -Archive
                     if ($archiveStats) {
                         $archiveSize = Convert-MbxSizeToGB -SizeObject $archiveStats.TotalItemSize
-                        $archiveQuota = Resolve-MbxQuotaValue -RawValue $mailbox.ArchiveQuota -Round:$Round
                         if ($archiveQuota -is [double] -and $archiveQuota -gt 0) {
                             $archivePercentUsed = [Math]::Round(($archiveSize / $archiveQuota) * 100, 2)
                         }
@@ -434,6 +703,7 @@ function Get-MboxStatistics {
 
                 if ($IncludeArchive) {
                     $record.ArchiveSizeGB = $archiveSize
+                    $record.ArchiveQuotaGB = $archiveQuota
                     $record.ArchivePercentUsed = $archivePercentUsed
                 }
 

--- a/Public/NC.Utils.ps1
+++ b/Public/NC.Utils.ps1
@@ -98,3 +98,54 @@ function Format-SortedEmailsFromClipboard {
 }
 
 Set-Alias -Name fse -Value Format-SortedEmailsFromClipboard -Description "Format sorted e-mails from clipboard"
+
+function Format-QuotedListFromClipboard {
+    <#
+    .SYNOPSIS
+        Formats clipboard text as a quoted, comma-separated list.
+    .DESCRIPTION
+        Reads text from the clipboard, splits it on lines and tabs, trims each value, removes
+        duplicates while preserving the first occurrence, and copies the resulting quoted list
+        back to the clipboard.
+    .PARAMETER PassThru
+        Emit the formatted string to the pipeline in addition to copying it to the clipboard.
+    .EXAMPLE
+        Format-QuotedListFromClipboard -PassThru
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$PassThru
+    )
+
+    $clipboard = Get-Clipboard -Raw
+    if ([string]::IsNullOrWhiteSpace($clipboard)) {
+        Write-NCMessage "Clipboard is empty. Copy a list of values first." -Level WARNING
+        return
+    }
+
+    $items = $clipboard -split "\r?\n|\t" | ForEach-Object {
+        $_.Trim().Trim('"').Trim("'")
+    } | Where-Object { $_ }
+
+    if (-not $items -or $items.Count -eq 0) {
+        Write-NCMessage "No values found in clipboard content." -Level WARNING
+        return
+    }
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $normalized = [System.Collections.Generic.List[string]]::new()
+    foreach ($item in $items) {
+        if ($seen.Add($item)) {
+            $normalized.Add($item) | Out-Null
+        }
+    }
+
+    $quoted = $normalized | ForEach-Object { "`"$($_.Replace('"', '""'))`"" }
+    $output = $quoted -join ","
+
+    $output | Set-Clipboard
+    $label = if ($normalized.Count -eq 1) { 'value' } else { 'values' }
+    Write-NCMessage ("Copied {0} formatted {1} to clipboard." -f $normalized.Count, $label) -Level INFO
+
+    if ($PassThru.IsPresent) { $output }
+}


### PR DESCRIPTION
## Summary
- Add Entra security group creation helper and owner management helpers.
- Add group clone workflow to copy description, owners, and members into a new or existing Entra group.
- Add simple Entra group edit helpers for description and display name.
- Update module export list and group usage docs.

## Validation
- Parsed `Public/NC.Groups.ps1` successfully.
- Imported `Nebula.Core.psd1` successfully.
- Verified the new public commands are exported by the module.